### PR TITLE
Add integrated intensity export and map session persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/features/HYBRID_APPROACH_GUIDE.md
+++ b/docs/features/HYBRID_APPROACH_GUIDE.md
@@ -1,0 +1,241 @@
+# Как использовать гибридный подход для планирования
+
+Этот документ объясняет, как создан план реализации панели результатов и как работать с ним дальше.
+
+## 📁 Что было создано
+
+### 1. Подробный план реализации
+**Файл:** `docs/features/results-panel-implementation-plan.md`
+
+Полный технический документ, который включает:
+- Описание функциональности
+- Архитектурные решения
+- 7 фаз реализации с детальными задачами
+- Структуру файлов
+- Примеры кода
+- Оценки времени (15-20 часов)
+- Критерии успеха
+
+**Преимущества:**
+- Вся информация в одном месте
+- Версионируется вместе с кодом
+- Можно обновлять по мере работы
+- Служит документацией на будущее
+
+### 2. Индекс документации
+**Файл:** `docs/features/README.md`
+
+Оглавление всех feature планов в репозитории:
+- Список активных планов
+- Статусы и приоритеты
+- Инструкции по использованию
+
+### 3. Шаблон для GitHub Issue
+**Файл:** `docs/features/ISSUE_TEMPLATE_results_panel.md`
+
+Готовый текст для создания epic issue в GitHub:
+- Краткое описание функций
+- Список всех фаз с чекбоксами
+- Ссылка на полный план
+- Критерии успеха
+
+## 🚀 Следующие шаги
+
+### Шаг 1: Создать Epic Issue в GitHub
+
+1. Зайти на https://github.com/timnik82/RamanLab/issues/new
+2. Скопировать содержимое файла `docs/features/ISSUE_TEMPLATE_results_panel.md`
+3. Вставить как текст issue
+4. Добавить labels: `feature`, `enhancement`, `peak-fitting`, `ui`
+5. Создать issue
+
+**Результат:** Получите issue с номером (например, #7), который будет главным tracking issue
+
+### Шаг 2: Начать реализацию
+
+#### Вариант А: Реализовывать последовательно
+
+Для каждой фазы:
+1. Создать отдельный issue (опционально):
+   - Title: "Phase 1: Base Panel Structure"
+   - Ссылка на epic: "Part of #7"
+   - Описание из плана
+2. Создать ветку: `git checkout -b feature/results-panel-phase1`
+3. Реализовать задачи из фазы
+4. Коммиты: `git commit -m "Implement base panel structure. Refs #7"`
+5. Push и создать PR с пометкой "Part of #7"
+
+#### Вариант Б: Реализовывать всё сразу
+
+1. Создать одну ветку: `git checkout -b feature/results-panel`
+2. Реализовывать все фазы последовательно
+3. Коммиты: `git commit -m "Phase 1: Base panel. Refs #7"`
+4. Один большой PR в конце
+
+**Рекомендация:** Вариант А (по фазам) лучше для:
+- Получения промежуточной обратной связи
+- Упрощения code review
+- Возможности использовать частичный функционал
+
+### Шаг 3: Отслеживание прогресса
+
+**В Epic Issue (#7):**
+- Отмечать галочками завершенные задачи
+- Добавлять номера sub-issues по мере создания
+- Обновлять, если планы меняются
+
+**В коммитах:**
+```bash
+# Для промежуточных коммитов
+git commit -m "Add statistics computation. Refs #7"
+
+# Для завершения фазы/задачи
+git commit -m "Complete Phase 2: Overall statistics display. Refs #7"
+
+# Для завершения всего feature (закрывает issue)
+git commit -m "Complete Results Panel implementation. Closes #7"
+```
+
+**В pull requests:**
+- Title: "Feature: Results Panel - Phase 1" или "Feature: Results Panel (complete)"
+- Description: ссылка на epic "Closes #7" или "Part of #7"
+
+### Шаг 4: Обновление документации
+
+По мере реализации:
+1. Если архитектура меняется → обновить план
+2. Если добавляются новые фазы → добавить в план
+3. Если что-то отменяется → пометить в плане
+4. Коммит изменений плана вместе с кодом
+
+## 📊 Структура работы
+
+```
+Epic Issue #7 (GitHub)
+  │
+  ├─ Фаза 1 → Issue #8 (опц.)
+  │   ├─ Commit: "Create base panel. Refs #7"
+  │   ├─ Commit: "Add to main window. Refs #7"
+  │   └─ PR #9 → "Part of #7"
+  │
+  ├─ Фаза 2 → Issue #10 (опц.)
+  │   ├─ Commit: "Add statistics computation. Refs #7"
+  │   └─ PR #11 → "Part of #7"
+  │
+  └─ ... (остальные фазы)
+```
+
+## 💡 Советы по реализации
+
+### Начать с MVP (Minimum Viable Product)
+Фазы 1-3 (8-10 часов) дают работающую базовую функциональность:
+- Панель появляется после фиттинга
+- Показывает общую статистику
+- Клик на карте показывает детали
+
+Это позволит:
+- ✅ Быстро получить feedback от пользователей
+- ✅ Проверить, что архитектура правильная
+- ✅ Начать использовать feature раньше
+
+Фазы 4-7 добавляются потом по необходимости.
+
+### Использовать существующий код
+В плане указаны функции для переиспользования:
+- `compute_integrated_intensity()` из `core/math_models.py`
+- `ConfigManager` для сохранения настроек
+- Существующие Qt widgets и стили
+
+### Тестировать на реальных данных
+После каждой фазы:
+1. Запустить приложение
+2. Загрузить карту кремния
+3. Сделать peak fitting
+4. Проверить, что новая функциональность работает
+
+## 📝 Пример workflow
+
+```bash
+# 1. Создать Epic Issue в GitHub (получить номер, например #7)
+
+# 2. Создать ветку для Phase 1
+git checkout -b feature/results-panel-phase1
+
+# 3. Создать файлы для Phase 1
+# map_analysis_2d/ui/results_panel.py
+# ... код ...
+
+# 4. Коммит
+git add map_analysis_2d/ui/results_panel.py
+git commit -m "Create ResultsPanel base class
+
+Implement QDockWidget-based panel with two sections:
+- OverallStatsWidget for aggregate statistics
+- PixelDetailsWidget for point-specific data
+
+Panel can be docked, floated, and hidden via View menu.
+
+Phase 1 of Results Panel implementation.
+Refs #7"
+
+# 5. Интеграция в main_window.py
+git add map_analysis_2d/ui/main_window.py
+git commit -m "Integrate ResultsPanel into main window
+
+Add results panel as dockable widget on right side.
+Add View menu option to show/hide panel.
+
+Refs #7"
+
+# 6. Push и PR
+git push -u origin feature/results-panel-phase1
+gh pr create --title "Feature: Results Panel - Phase 1" --body "Part of #7
+
+Implements Phase 1: Base Panel Structure
+- Creates ResultsPanel as QDockWidget
+- Adds to main window
+- View menu integration
+
+See implementation plan: docs/features/results-panel-implementation-plan.md"
+
+# 7. После merge, перейти к Phase 2
+git checkout main
+git pull
+git checkout -b feature/results-panel-phase2
+# ... повторить процесс ...
+```
+
+## 🎯 Цель гибридного подхода
+
+**Документация в репозитории + Tracking в GitHub = Лучшее из обоих подходов**
+
+### Преимущества:
+✅ **Подробный план** всегда доступен и версионирован
+✅ **GitHub Issues** для tracking и обсуждений
+✅ **Гибкость** в разделении работы на части
+✅ **Документация** остается после завершения
+✅ **История** решений и изменений
+
+### Избегаем проблем:
+❌ Фрагментированная информация (все issues разрозненные)
+❌ Потерянная документация (только issues, которые закрываются)
+❌ Негибкость (монолитный mega-issue)
+❌ Отсутствие контекста (коммиты без ссылок на issue)
+
+## 📞 Когда обновлять план
+
+План нужно обновлять, если:
+- Меняется архитектура или технический подход
+- Добавляются новые требования
+- Обнаруживаются неучтенные сложности
+- Меняется приоритизация фаз
+- Появляется важная информация (performance issues, и т.д.)
+
+План НЕ нужно обновлять для:
+- Мелких багфиксов
+- Изменений в реализации без изменения подхода
+- Рефакторинга без изменения функциональности
+
+---
+
+**Готово!** Теперь можно начинать реализацию. Удачи! 🚀

--- a/docs/features/HYBRID_APPROACH_GUIDE.md
+++ b/docs/features/HYBRID_APPROACH_GUIDE.md
@@ -110,7 +110,7 @@ git commit -m "Complete Results Panel implementation. Closes #7"
 
 ## 📊 Структура работы
 
-```
+```text
 Epic Issue #7 (GitHub)
   │
   ├─ Фаза 1 → Issue #8 (опц.)

--- a/docs/features/ISSUE_TEMPLATE_results_panel.md
+++ b/docs/features/ISSUE_TEMPLATE_results_panel.md
@@ -97,7 +97,7 @@ Click on any point on the map to see:
 
 ## 🎨 UI Mockup
 
-```
+```text
 ┌─ Results Summary ──────────────────┐
 │ Overall Statistics                  │
 │ ├─ Total Area: 123,456.78          │

--- a/docs/features/ISSUE_TEMPLATE_results_panel.md
+++ b/docs/features/ISSUE_TEMPLATE_results_panel.md
@@ -1,0 +1,178 @@
+# Epic: Permanent Results Panel for Peak Fitting
+
+## 🎯 Overview
+
+Implement a permanent results panel in the Peak Fitting interface that displays overall statistics and interactive pixel-specific details.
+
+**Status:** 📋 Planning
+**Priority:** 🔴 High
+**Target Version:** 2.1.0
+**Estimated Effort:** 15-20 hours
+
+## 📖 Full Implementation Plan
+
+See detailed implementation plan: [docs/features/results-panel-implementation-plan.md](../docs/features/results-panel-implementation-plan.md)
+
+## ✨ Key Features
+
+### 1. Overall Statistics Display
+After peak fitting completion, automatically show:
+- ✅ Total integrated area across entire map
+- ✅ Number of successfully fitted pixels
+- ✅ Mean, median, standard deviation
+- ✅ Per-peak statistics (when multiple peaks)
+- ✅ Success rate
+
+### 2. Interactive Pixel Details
+Click on any point on the map to see:
+- ✅ Pixel coordinates (X, Y)
+- ✅ Integrated intensity per peak
+- ✅ All fit parameters (amplitude, center, width)
+- ✅ Fit quality (R-squared)
+- ✅ Fit status (success/warning/error)
+
+### 3. Export & Copy
+- ✅ Export statistics summary to text file
+- ✅ Copy statistics to clipboard
+- ✅ Export individual pixel data
+- ✅ Show spectrum for selected pixel
+
+## 🏗️ Implementation Phases
+
+### Phase 1: Base Panel Structure ⏱️ 2-3h
+- [ ] Create `map_analysis_2d/ui/results_panel.py`
+- [ ] Implement `ResultsPanel` as QDockWidget
+- [ ] Integrate into main window
+- [ ] Add View menu toggle
+
+**Subtask Issue:** #TBD
+
+### Phase 2: Overall Statistics Display ⏱️ 2-3h
+- [ ] Create `map_analysis_2d/core/statistics.py`
+- [ ] Implement statistics computation
+- [ ] Connect to peak fitting completion
+- [ ] Display formatted results
+
+**Subtask Issue:** #TBD
+
+### Phase 3: Pixel Details on Click ⏱️ 3-4h
+- [ ] Implement map click event handler
+- [ ] Convert click coordinates to pixel position
+- [ ] Update panel with pixel details
+- [ ] Add visual marker on map
+
+**Subtask Issue:** #TBD
+
+### Phase 4: Export & Copy Functionality ⏱️ 1-2h
+- [ ] Export summary to .txt file
+- [ ] Copy to clipboard
+- [ ] Show spectrum for selected pixel
+- [ ] Export pixel data
+
+**Subtask Issue:** #TBD
+
+### Phase 5: Visual Improvements ⏱️ 1-2h
+- [ ] Color coding for fit quality
+- [ ] Icons and better styling
+- [ ] Mini histogram for distribution
+- [ ] Tooltips
+
+**Subtask Issue:** #TBD
+
+### Phase 6: State Persistence ⏱️ 1h
+- [ ] Save panel position/size to config
+- [ ] Save visibility state
+- [ ] Restore on startup
+
+**Subtask Issue:** #TBD
+
+### Phase 7: Testing & Documentation ⏱️ 2-3h
+- [ ] Test with real data
+- [ ] Test edge cases
+- [ ] Performance testing on large maps
+- [ ] Update README
+- [ ] Add user guide
+
+**Subtask Issue:** #TBD
+
+## 🎨 UI Mockup
+
+```
+┌─ Results Summary ──────────────────┐
+│ Overall Statistics                  │
+│ ├─ Total Area: 123,456.78          │
+│ ├─ Fitted Pixels: 2,500/2,500      │
+│ ├─ Success Rate: 98.2%             │
+│ └─ Mean Area: 49.38 ± 12.45        │
+│                                     │
+│ [Export Summary] [Copy]             │
+├─────────────────────────────────────┤
+│ Selected Pixel Details              │
+│ Position: (X=10, Y=15)              │
+│                                     │
+│ Integrated Intensities:             │
+│ ├─ Peak 1: 45.23                   │
+│ └─ Peak 2: 12.15                   │
+│                                     │
+│ [Show Spectrum] [Export]            │
+└─────────────────────────────────────┘
+```
+
+## 📋 Minimum Viable Product (MVP)
+
+**Phases 1-3 (8-10 hours):**
+- Base panel structure
+- Overall statistics display
+- Pixel details on click
+
+This provides core functionality without export features or visual polish.
+
+## ✅ Success Criteria
+
+### Functional
+- [ ] Panel displays correctly after peak fitting
+- [ ] Statistics are mathematically accurate
+- [ ] Map clicks update pixel details immediately
+- [ ] Export functions work correctly
+
+### User Experience
+- [ ] Intuitive and easy to read
+- [ ] Fast response to clicks (<100ms)
+- [ ] Doesn't obstruct map view
+- [ ] Clear number formatting
+
+### Code Quality
+- [ ] Follows existing code style
+- [ ] Properly documented
+- [ ] No performance degradation
+- [ ] Error handling implemented
+
+## 🔗 Related
+
+- **User Request:** [Original conversation]
+- **Related Commit:** b67bebd - Add integrated intensity export and map session persistence
+- **Implementation Plan:** [docs/features/results-panel-implementation-plan.md](../docs/features/results-panel-implementation-plan.md)
+
+## 💡 Future Enhancements
+
+Ideas for future versions:
+- Multi-pixel selection (shift+click)
+- Statistics filtering by R² threshold
+- Compare different fitting runs
+- Export to Excel with charts
+- Historical tracking via database
+
+---
+
+## 📝 Implementation Notes
+
+As you work on this feature:
+1. Create separate issues for each phase as you start them
+2. Link commits using `Refs #XXX` (this issue number)
+3. Update this issue description if requirements change
+4. Check off tasks as completed
+5. Update the implementation plan document if needed
+
+## 🏷️ Labels
+
+`feature`, `enhancement`, `peak-fitting`, `ui`, `results-panel`

--- a/docs/features/ISSUE_TEMPLATE_results_panel.md
+++ b/docs/features/ISSUE_TEMPLATE_results_panel.md
@@ -11,7 +11,7 @@ Implement a permanent results panel in the Peak Fitting interface that displays 
 
 ## 📖 Full Implementation Plan
 
-See detailed implementation plan: [docs/features/results-panel-implementation-plan.md](../docs/features/results-panel-implementation-plan.md)
+See detailed implementation plan: [docs/features/results-panel-implementation-plan.md](results-panel-implementation-plan.md)
 
 ## ✨ Key Features
 
@@ -151,7 +151,7 @@ This provides core functionality without export features or visual polish.
 
 - **User Request:** [Original conversation]
 - **Related Commit:** b67bebd - Add integrated intensity export and map session persistence
-- **Implementation Plan:** [docs/features/results-panel-implementation-plan.md](../docs/features/results-panel-implementation-plan.md)
+- **Implementation Plan:** [docs/features/results-panel-implementation-plan.md](results-panel-implementation-plan.md)
 
 ## 💡 Future Enhancements
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,59 @@
+# Feature Implementation Plans
+
+This directory contains detailed implementation plans for major features in RamanLab.
+
+## Active Plans
+
+### [Results Panel Implementation](results-panel-implementation-plan.md)
+**Status:** Planning
+**Priority:** High
+**Target Version:** 2.1.0
+
+Implementation of a permanent results panel in the Peak Fitting interface that displays overall statistics and pixel-specific details when clicking on the map.
+
+**Key Features:**
+- Overall statistics display (total area, mean, median, etc.)
+- Interactive pixel details on map click
+- Export and copy functionality
+- Persistent panel state
+
+---
+
+## How to Use These Plans
+
+### For Developers
+1. Read the full implementation plan before starting work
+2. Create a tracking issue (epic) in GitHub with a summary and link to the plan
+3. Break work into smaller tasks/issues for each phase
+4. Link commits to issues using `Refs #XXX` or `Closes #XXX`
+5. Update the plan if requirements change
+
+### For Project Management
+- Each plan includes time estimates and prioritization
+- Track progress using GitHub issues linked to phases
+- Plans are versioned with the code for historical reference
+
+### For Contributors
+- Plans provide context for understanding new features
+- Include architectural decisions and code structure
+- Serve as documentation for future maintenance
+
+---
+
+## Plan Template
+
+When creating new feature plans, include:
+
+1. **Overview** - What is being built and why
+2. **User Requirements** - Original user request/need
+3. **Architecture** - Technical design decisions
+4. **Implementation Phases** - Step-by-step breakdown
+5. **File Structure** - What files will be created/modified
+6. **Technical Requirements** - Dependencies, compatibility
+7. **Testing Strategy** - How to verify success
+8. **Time Estimates** - Effort required per phase
+9. **Success Criteria** - Definition of done
+
+---
+
+**Last Updated:** 2026-05-01

--- a/docs/features/results-panel-implementation-plan.md
+++ b/docs/features/results-panel-implementation-plan.md
@@ -77,7 +77,7 @@ Implementation of a permanent results panel in the Peak Fitting interface that d
 
 **Tasks:**
 - [ ] Create new file `map_analysis_2d/ui/results_panel.py`
-- [ ] Implement `ResultsPanel(QWidget)` class
+- [ ] Implement `ResultsPanel(QDockWidget)` class
 - [ ] Create two main sections:
   - `OverallStatsWidget` - overall statistics section
   - `PixelDetailsWidget` - pixel details section
@@ -103,7 +103,9 @@ class ResultsPanel(QDockWidget):
 
         # Add to layout
         self.layout.addWidget(self.overall_stats)
-        self.layout.addWidget(QSplitter())
+        separator = QFrame()
+        separator.setFrameShape(QFrame.HLine)
+        self.layout.addWidget(separator)
         self.layout.addWidget(self.pixel_details)
 
         self.setWidget(self.main_widget)
@@ -123,7 +125,7 @@ class ResultsPanel(QDockWidget):
   - Per-peak totals (if multiple peaks)
 - [ ] Implement `update_overall_stats(results_dict)` method
 - [ ] Format numbers appropriately (thousands separators, scientific notation)
-- [ ] Connect to peak fitting worker completion signal
+- [ ] Connect to peak fitting worker completion signal (decorate slot with `@Slot` — worker runs on QThread, UI updates must arrive on the main thread via Qt's signal/slot mechanism)
 - [ ] Handle edge cases (no data, all failed fits, etc.)
 
 **Files to modify:**
@@ -380,7 +382,7 @@ if cfg.get('results_panel.visible', True):
 - [ ] Add screenshots
 
 **Files to modify:**
-- Modified: `/home/runner/work/RamanLab/RamanLab/README.md`
+- Modified: `README.md`
 - New: `docs/user_guide/results_panel.md` (optional)
 
 ## File Structure

--- a/docs/features/results-panel-implementation-plan.md
+++ b/docs/features/results-panel-implementation-plan.md
@@ -1,0 +1,536 @@
+# Results Panel Implementation Plan
+
+## Overview
+
+Implementation of a permanent results panel in the Peak Fitting interface that displays:
+1. Overall statistics after fitting completion (total area, count, mean, etc.)
+2. Detailed information about a specific pixel when clicking on the map
+3. Automatic updates and always visible
+
+**Status:** Planning
+**Priority:** High
+**Estimated Time:** 15-20 hours
+**Target Version:** 2.1.0
+
+## User Requirements
+
+> "Когда появляется постоянная панель с результатами, которые ты предложил, то есть в ней будет показываться всегда, после того как фитинг произошел, общее количество, общая площадь, а также будет значение точечные. То есть, когда я тыкаю мышкой на определенную точку карты, должны показываться значения в этой точке."
+
+### Key Features
+- Permanent panel showing results after peak fitting
+- Overall statistics: total area, total count, averages
+- Click on map point → show values for that specific pixel
+- Always visible during peak fitting workflow
+
+## Architecture
+
+### Panel Location
+- **Position:** Right side of Peak Fitting interface
+- **Implementation:** QDockWidget (allows moving/hiding)
+- **Size:** Minimum width 250px, recommended 300-350px
+- **State:** Dockable, resizable, closable via View menu
+
+### Panel Structure
+
+```
+┌─ Results Summary ──────────────────┐
+│ Overall Statistics                  │
+│ ├─ Total Area: 123,456.78          │
+│ ├─ Fitted Pixels: 2,500/2,500      │
+│ ├─ Success Rate: 98.2%             │
+│ ├─ Mean Area: 49.38 ± 12.45        │
+│ └─ Median Area: 47.82              │
+│                                     │
+│ Per-Peak Statistics:                │
+│ ├─ Peak 1 Total: 95,234.56         │
+│ └─ Peak 2 Total: 28,222.22         │
+│                                     │
+│ [Export Summary] [Copy to Clipboard]│
+├─────────────────────────────────────┤
+│ Selected Pixel Details              │
+│ Position: (X=10, Y=15)              │
+│                                     │
+│ Integrated Intensities:             │
+│ ├─ Peak 1: 45.23                   │
+│ ├─ Peak 2: 12.15                   │
+│ └─ Total: 57.38                    │
+│                                     │
+│ Fit Parameters:                     │
+│ ├─ P1_Amp: 1234.5                  │
+│ ├─ P1_Cen: 520.3                   │
+│ ├─ P1_Wid: 8.2                     │
+│ └─ ...                              │
+│                                     │
+│ Fit Quality:                        │
+│ ├─ R²: 0.9845                      │
+│ └─ Status: ✓ Success               │
+│                                     │
+│ [Show Spectrum] [Export Point Data] │
+└─────────────────────────────────────┘
+```
+
+## Implementation Phases
+
+### Phase 1: Base Panel Structure (2-3 hours)
+
+**Goal:** Create the basic panel widget and integrate it into main window
+
+**Tasks:**
+- [ ] Create new file `map_analysis_2d/ui/results_panel.py`
+- [ ] Implement `ResultsPanel(QWidget)` class
+- [ ] Create two main sections:
+  - `OverallStatsWidget` - overall statistics section
+  - `PixelDetailsWidget` - pixel details section
+- [ ] Integrate panel into `main_window.py` as QDockWidget
+- [ ] Add View menu option to show/hide panel
+- [ ] Basic styling and layout
+
+**Files to modify:**
+- New: `map_analysis_2d/ui/results_panel.py`
+- Modified: `map_analysis_2d/ui/main_window.py`
+
+**Code Structure:**
+```python
+class ResultsPanel(QDockWidget):
+    def __init__(self, parent=None):
+        super().__init__("Results Summary", parent)
+        self.main_widget = QWidget()
+        self.layout = QVBoxLayout(self.main_widget)
+
+        # Create sections
+        self.overall_stats = OverallStatsWidget()
+        self.pixel_details = PixelDetailsWidget()
+
+        # Add to layout
+        self.layout.addWidget(self.overall_stats)
+        self.layout.addWidget(QSplitter())
+        self.layout.addWidget(self.pixel_details)
+
+        self.setWidget(self.main_widget)
+```
+
+### Phase 2: Overall Statistics Display (2-3 hours)
+
+**Goal:** Compute and display overall statistics after peak fitting
+
+**Tasks:**
+- [ ] Create `compute_overall_statistics()` function
+- [ ] Calculate key metrics:
+  - Total integrated area (sum of all Total_IntInt)
+  - Number of fitted pixels / total pixels
+  - Success rate (% of successful fits based on R²)
+  - Mean, median, std dev for Total_IntInt
+  - Per-peak totals (if multiple peaks)
+- [ ] Implement `update_overall_stats(results_dict)` method
+- [ ] Format numbers appropriately (thousands separators, scientific notation)
+- [ ] Connect to peak fitting worker completion signal
+- [ ] Handle edge cases (no data, all failed fits, etc.)
+
+**Files to modify:**
+- New: `map_analysis_2d/core/statistics.py`
+- Modified: `map_analysis_2d/ui/results_panel.py`
+- Modified: `map_analysis_2d/ui/main_window.py`
+
+**Statistics Computation:**
+```python
+def compute_overall_statistics(map_data, peak_fitting_results):
+    """Compute overall statistics from peak fitting results."""
+    stats = {
+        'total_area': 0.0,
+        'mean_area': 0.0,
+        'median_area': 0.0,
+        'std_area': 0.0,
+        'fitted_count': 0,
+        'total_count': len(map_data.spectra),
+        'success_rate': 0.0,
+        'per_peak_totals': {}
+    }
+
+    # Extract data
+    total_areas = []
+    shapes = peak_fitting_results['peak_shapes']
+    map_params = peak_fitting_results['map_parameters']
+
+    for pos_key, spectrum in map_data.spectra.items():
+        # Compute total IntInt for this pixel
+        total_int = 0.0
+        all_valid = True
+
+        for i, shape in enumerate(shapes, 1):
+            amp = map_params.get(f'P{i}_Amp', {}).get(pos_key, np.nan)
+            wid = map_params.get(f'P{i}_Wid', {}).get(pos_key, np.nan)
+            eta = map_params.get(f'P{i}_Eta', {}).get(pos_key, 0.5)
+
+            if np.isfinite(amp) and np.isfinite(wid):
+                ii = compute_integrated_intensity(amp, wid, shape, eta)
+                total_int += ii
+
+                # Per-peak tracking
+                peak_key = f'Peak {i}'
+                if peak_key not in stats['per_peak_totals']:
+                    stats['per_peak_totals'][peak_key] = 0.0
+                stats['per_peak_totals'][peak_key] += ii
+            else:
+                all_valid = False
+
+        if all_valid:
+            total_areas.append(total_int)
+            stats['fitted_count'] += 1
+
+    # Calculate statistics
+    if total_areas:
+        stats['total_area'] = np.sum(total_areas)
+        stats['mean_area'] = np.mean(total_areas)
+        stats['median_area'] = np.median(total_areas)
+        stats['std_area'] = np.std(total_areas)
+        stats['success_rate'] = (stats['fitted_count'] / stats['total_count']) * 100
+
+    return stats
+```
+
+### Phase 3: Pixel Details on Map Click (3-4 hours)
+
+**Goal:** Show detailed information when user clicks on a pixel in the map
+
+**Tasks:**
+- [ ] Implement map click event handler in main_window
+- [ ] Connect matplotlib event (`button_press_event`) to handler
+- [ ] Convert click coordinates to map pixel position
+- [ ] Find closest pixel with data
+- [ ] Implement `update_pixel_details(pos, results)` method
+- [ ] Display pixel information:
+  - Coordinates (X, Y)
+  - Integrated intensity per peak
+  - Total integrated intensity
+  - All fit parameters (Amp, Cen, Wid, Eta)
+  - R-squared value
+  - Fit status (Success/Warning/Error)
+- [ ] Add visual marker on map for selected pixel
+- [ ] Clear previous selection marker when new pixel is clicked
+
+**Files to modify:**
+- Modified: `map_analysis_2d/ui/results_panel.py`
+- Modified: `map_analysis_2d/ui/main_window.py`
+
+**Click Handler Implementation:**
+```python
+def _connect_map_click_handler(self):
+    """Connect click handler to peak fitting map."""
+    if hasattr(self, 'peak_fitting_plot_widget'):
+        canvas = self.peak_fitting_plot_widget.canvas
+        self._map_click_cid = canvas.mpl_connect(
+            'button_press_event', self._on_peak_fitting_map_click
+        )
+
+def _on_peak_fitting_map_click(self, event):
+    """Handle click on peak fitting map."""
+    if not event.inaxes or self.peak_fitting_results is None:
+        return
+
+    x_click = event.xdata
+    y_click = event.ydata
+
+    # Find closest pixel
+    closest_pos = self._find_closest_pixel(x_click, y_click)
+
+    if closest_pos:
+        # Update results panel
+        self.results_panel.update_pixel_details(
+            closest_pos,
+            self.peak_fitting_results,
+            self.map_data
+        )
+
+        # Add visual marker
+        self._highlight_selected_pixel(closest_pos)
+
+def _find_closest_pixel(self, x, y):
+    """Find the closest pixel to clicked coordinates."""
+    min_dist = float('inf')
+    closest_pos = None
+
+    for pos_key in self.map_data.spectra.keys():
+        px, py = pos_key
+        dist = np.sqrt((px - x)**2 + (py - y)**2)
+        if dist < min_dist:
+            min_dist = dist
+            closest_pos = pos_key
+
+    return closest_pos
+
+def _highlight_selected_pixel(self, pos):
+    """Add visual marker for selected pixel on map."""
+    if hasattr(self, '_selected_pixel_marker') and self._selected_pixel_marker:
+        self._selected_pixel_marker.remove()
+
+    ax = self.peak_fitting_plot_widget.ax
+    x, y = pos
+    self._selected_pixel_marker = ax.plot(
+        x, y, 'r*', markersize=15, markeredgecolor='white',
+        markeredgewidth=1.5, zorder=100
+    )[0]
+    self.peak_fitting_plot_widget.canvas.draw_idle()
+```
+
+### Phase 4: Export and Copy Functionality (1-2 hours)
+
+**Goal:** Allow users to export and copy statistics
+
+**Tasks:**
+- [ ] Implement "Export Summary" button
+  - Save statistics to .txt file
+  - Include all overall statistics
+  - Timestamp and map filename
+- [ ] Implement "Copy to Clipboard" button
+  - Format statistics as text
+  - Copy to system clipboard
+- [ ] Implement "Show Spectrum" button (for selected pixel)
+  - Open spectrum in separate plot window
+  - Show fit overlay
+- [ ] Implement "Export Point Data" button
+  - Export selected pixel data to CSV
+  - Include all parameters and integrated intensities
+
+**Files to modify:**
+- Modified: `map_analysis_2d/ui/results_panel.py`
+- Modified: `map_analysis_2d/ui/main_window.py`
+
+**Export Format:**
+```
+RamanLab Peak Fitting Results Summary
+Generated: 2026-05-01 19:35:00
+Map: silicon_sample_map.h5
+
+OVERALL STATISTICS
+==================
+Total Integrated Area: 123,456.78
+Fitted Pixels: 2,500 / 2,500
+Success Rate: 98.2%
+Mean Area: 49.38 ± 12.45
+Median Area: 47.82
+
+PER-PEAK STATISTICS
+===================
+Peak 1 Total: 95,234.56
+Peak 2 Total: 28,222.22
+```
+
+### Phase 5: Visual Improvements (1-2 hours)
+
+**Goal:** Enhance visual appearance and usability
+
+**Tasks:**
+- [ ] Add color coding (green for good fits, yellow/red for poor)
+- [ ] Add icons for sections and buttons
+- [ ] Create mini histogram for area distribution
+- [ ] Add tooltips with additional information
+- [ ] Implement number format toggle (scientific notation on/off)
+- [ ] Add collapsible sections
+- [ ] Improve spacing and alignment
+- [ ] Add loading indicator during computation
+
+**Files to modify:**
+- Modified: `map_analysis_2d/ui/results_panel.py`
+- New: `map_analysis_2d/ui/widgets/` (optional widget submodules)
+
+### Phase 6: State Persistence (1 hour)
+
+**Goal:** Remember panel state between sessions
+
+**Tasks:**
+- [ ] Save panel position and size to config
+- [ ] Save panel visibility state (shown/hidden)
+- [ ] Save format preferences (scientific notation, etc.)
+- [ ] Restore state on startup
+- [ ] Use existing ConfigManager
+
+**Files to modify:**
+- Modified: `map_analysis_2d/ui/main_window.py`
+- Modified: `map_analysis_2d/ui/results_panel.py`
+
+**Config Storage:**
+```python
+# Save state
+cfg.set('results_panel.visible', self.results_panel.isVisible())
+cfg.set('results_panel.width', self.results_panel.width())
+cfg.set('results_panel.floating', self.results_panel.isFloating())
+cfg.set('results_panel.scientific_notation', self.results_panel.use_scientific)
+
+# Restore state
+if cfg.get('results_panel.visible', True):
+    self.results_panel.show()
+```
+
+### Phase 7: Testing and Documentation (2-3 hours)
+
+**Goal:** Ensure robustness and document the feature
+
+**Tasks:**
+- [ ] Test with real silicon Raman data
+- [ ] Test with different map sizes (small, medium, large)
+- [ ] Test edge cases:
+  - No successful fits
+  - Single pixel map
+  - Multiple peak shapes
+  - Missing parameters
+- [ ] Performance testing on large maps (10,000+ pixels)
+- [ ] Add docstrings to all new functions
+- [ ] Update README.md with new feature description
+- [ ] Create user guide section in docs
+- [ ] Add screenshots
+
+**Files to modify:**
+- Modified: `/home/runner/work/RamanLab/RamanLab/README.md`
+- New: `docs/user_guide/results_panel.md` (optional)
+
+## File Structure
+
+```
+map_analysis_2d/
+├── ui/
+│   ├── __init__.py              # Update exports
+│   ├── results_panel.py         # NEW: Main panel class
+│   ├── widgets/                 # NEW: (optional) Widget submodules
+│   │   ├── __init__.py
+│   │   ├── overall_stats.py    # NEW: Overall statistics widget
+│   │   └── pixel_details.py    # NEW: Pixel details widget
+│   └── main_window.py          # MODIFIED: Panel integration
+└── core/
+    ├── __init__.py              # Update exports
+    └── statistics.py            # NEW: Statistics utilities
+
+docs/
+└── features/
+    ├── README.md                # NEW: Features index
+    └── results-panel-implementation-plan.md  # This document
+```
+
+## Technical Requirements
+
+### Dependencies
+- PySide6 (Qt6) - already included
+- NumPy - already included
+- Matplotlib - already included
+- No new dependencies required
+
+### Python Compatibility
+- Python 3.8+ (per repository standard)
+- Use type hints where appropriate
+- Follow existing code style
+
+### Performance Considerations
+- Statistics computation: O(n) where n = number of pixels
+- Click handling: O(n) for finding closest pixel (consider spatial index if slow)
+- Memory: Minimal additional memory (statistics dict only)
+- UI updates: Use Qt signals/slots for async updates
+
+### Error Handling
+- Handle missing/incomplete fit results gracefully
+- Validate pixel position before access
+- Catch and log matplotlib event errors
+- Display user-friendly error messages
+
+## Testing Strategy
+
+### Unit Tests
+- Statistics computation accuracy
+- Coordinate transformation
+- Data formatting functions
+
+### Integration Tests
+- Panel initialization with main window
+- Event handler connections
+- State persistence
+
+### Manual Tests
+- Click accuracy on different map sizes
+- Export file generation
+- Copy to clipboard functionality
+- Visual appearance on different platforms (Windows, macOS, Linux)
+
+## Time Estimates
+
+| Phase | Description | Time Estimate |
+|-------|-------------|---------------|
+| 1 | Base Panel Structure | 2-3 hours |
+| 2 | Overall Statistics | 2-3 hours |
+| 3 | Pixel Details on Click | 3-4 hours |
+| 4 | Export/Copy Functionality | 1-2 hours |
+| 5 | Visual Improvements | 1-2 hours |
+| 6 | State Persistence | 1 hour |
+| 7 | Testing & Documentation | 2-3 hours |
+| **Total** | **Full Implementation** | **15-20 hours** |
+
+### Minimum Viable Product (MVP)
+Phases 1-3 only: **8-10 hours**
+- Basic panel with overall statistics and pixel click details
+- No export functionality yet
+- Basic styling only
+
+## Prioritization
+
+### Must Have (Critical)
+- ✅ Phase 1: Base panel structure
+- ✅ Phase 2: Overall statistics display
+- ✅ Phase 3: Pixel details on click
+
+### Should Have (Important)
+- ⚠️ Phase 4: Export and copy functionality
+- ⚠️ Phase 6: State persistence
+
+### Nice to Have (Optional)
+- ➕ Phase 5: Enhanced visualization
+- ➕ Phase 7: Comprehensive testing
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] Panel displays after peak fitting completion
+- [ ] Shows total area and per-peak statistics
+- [ ] Click on map updates pixel details
+- [ ] All statistics are mathematically correct
+- [ ] Export functions work as expected
+
+### User Experience
+- [ ] Panel is intuitive and easy to read
+- [ ] Response to clicks is immediate (<100ms)
+- [ ] Panel doesn't obstruct map view
+- [ ] Numbers are formatted clearly
+
+### Code Quality
+- [ ] Follows existing code style
+- [ ] Properly documented
+- [ ] No performance degradation
+- [ ] Error handling implemented
+
+## Future Enhancements
+
+Potential improvements for future versions:
+- Multi-pixel selection (shift+click for range)
+- Statistics filtering (by R² threshold, area range)
+- Time-series analysis (if multiple maps)
+- Compare statistics between different fitting runs
+- Export statistics to Excel with charts
+- Integration with database for historical tracking
+
+## References
+
+- Related Issue: TBD (to be created)
+- Related PR: TBD
+- Related Commits:
+  - b67bebd - Add integrated intensity export and map session persistence
+- User Request: See issue comments
+
+## Notes
+
+- This feature builds on the integrated intensity export functionality added in commit b67bebd
+- The `compute_integrated_intensity()` function from `core/math_models.py` will be reused
+- Panel should be disabled/hidden when no peak fitting results are available
+- Consider accessibility (screen readers, keyboard navigation) in future iterations
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-05-01
+**Author:** Implementation planning session
+**Status:** Ready for implementation

--- a/docs/features/results-panel-implementation-plan.md
+++ b/docs/features/results-panel-implementation-plan.md
@@ -414,7 +414,7 @@ docs/
 - No new dependencies required
 
 ### Python Compatibility
-- Python 3.8+ (per repository standard)
+- Python 3.10+ (per repository standard)
 - Use type hints where appropriate
 - Follow existing code style
 

--- a/docs/features/results-panel-implementation-plan.md
+++ b/docs/features/results-panel-implementation-plan.md
@@ -32,7 +32,7 @@ Implementation of a permanent results panel in the Peak Fitting interface that d
 
 ### Panel Structure
 
-```
+```text
 ┌─ Results Summary ──────────────────┐
 │ Overall Statistics                  │
 │ ├─ Total Area: 123,456.78          │
@@ -298,7 +298,7 @@ def _highlight_selected_pixel(self, pos):
 - Modified: `map_analysis_2d/ui/main_window.py`
 
 **Export Format:**
-```
+```text
 RamanLab Peak Fitting Results Summary
 Generated: 2026-05-01 19:35:00
 Map: silicon_sample_map.h5
@@ -387,7 +387,7 @@ if cfg.get('results_panel.visible', True):
 
 ## File Structure
 
-```
+```text
 map_analysis_2d/
 ├── ui/
 │   ├── __init__.py              # Update exports

--- a/map_analysis_2d/core/math_models.py
+++ b/map_analysis_2d/core/math_models.py
@@ -64,8 +64,6 @@ def compute_integrated_intensity(amplitude: float, width: float, shape: str, eta
     """Analytical area under a fitted peak derived from its stored parameters."""
     amp = float(amplitude)
     wid = abs(float(width))
-    if amp < 0:
-        return np.nan
     if shape == "Gaussian":
         return amp * wid * np.sqrt(np.pi)
     elif shape == "Lorentzian":

--- a/map_analysis_2d/core/math_models.py
+++ b/map_analysis_2d/core/math_models.py
@@ -62,8 +62,10 @@ def create_multi_peak_model(shapes: List[str]):
 
 def compute_integrated_intensity(amplitude: float, width: float, shape: str, eta: float = 0.5) -> float:
     """Analytical area under a fitted peak derived from its stored parameters."""
-    amp = abs(float(amplitude))
+    amp = float(amplitude)
     wid = abs(float(width))
+    if amp < 0:
+        return np.nan
     if shape == "Gaussian":
         return amp * wid * np.sqrt(np.pi)
     elif shape == "Lorentzian":

--- a/map_analysis_2d/core/math_models.py
+++ b/map_analysis_2d/core/math_models.py
@@ -60,6 +60,20 @@ def create_multi_peak_model(shapes: List[str]):
         
     return multi_peak_model
 
+def compute_integrated_intensity(amplitude: float, width: float, shape: str, eta: float = 0.5) -> float:
+    """Analytical area under a fitted peak derived from its stored parameters."""
+    amp = abs(float(amplitude))
+    wid = abs(float(width))
+    if shape == "Gaussian":
+        return amp * wid * np.sqrt(np.pi)
+    elif shape == "Lorentzian":
+        return amp * wid * np.pi
+    elif shape == "Pseudo-Voigt":
+        eta = float(np.clip(eta, 0.0, 1.0))
+        return amp * wid * ((1.0 - eta) * np.sqrt(np.pi) + eta * np.pi)
+    return np.nan
+
+
 def get_param_names(shapes: List[str]) -> List[str]:
     """
     Returns a list of parameter names for a given sequence of peak shapes.

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -26,6 +26,7 @@ from ..core import RamanMapData
 from ..core.cosmic_ray_detection import CosmicRayConfig, SimpleCosmicRayManager
 from ..core.math_models import (
     DEFAULT_CURVE_FIT_MAXFEV,
+    compute_integrated_intensity,
     create_multi_peak_model,
     get_num_params_for_shape,
     get_param_names,
@@ -198,11 +199,47 @@ class MapAnalysisMainWindow(QMainWindow):
         self.setAcceptDrops(True)
         
         logger.info("Main window initialized")
-        
+
         # Try to auto-load database matching pattern RamanLab_Database_*.pkl
         # Do this AFTER UI is fully initialized
         self.auto_load_database()
+
+        # Restore the last opened map after the window is shown
+        from PySide6.QtCore import QTimer
+        QTimer.singleShot(0, self._restore_last_map)
     
+    def _restore_last_map(self):
+        """Reload the last opened map on startup, if the path still exists."""
+        try:
+            from core.config_manager import ConfigManager
+            from pathlib import Path
+            cfg = ConfigManager()
+            path = cfg.get('map_analysis.last_map_path')
+            kind = cfg.get('map_analysis.last_map_type')
+            if not path or not Path(path).exists():
+                return
+            self.progress_status.show_progress("Restoring last map...")
+            if kind == 'single_file':
+                from ..core.single_file_map_loader import SingleFileRamanMapData
+                self.map_data = SingleFileRamanMapData(
+                    filepath=path, cosmic_ray_config=self.cosmic_ray_config
+                )
+            else:
+                self.map_data = RamanMapData(path, cosmic_ray_config=self.cosmic_ray_config)
+            self._reset_peak_fitting_state(clear_config=True)
+            self._clear_map_cache()
+            self._initialize_integration_slider()
+            self.update_map()
+            self.progress_status.hide_progress()
+            self.statusBar().showMessage(
+                f"Restored last map: {Path(path).name} "
+                f"({len(self.map_data.spectra):,} spectra)"
+            )
+            logger.info("Restored last map from %s", path)
+        except Exception as e:
+            self.progress_status.hide_progress()
+            logger.warning("Could not restore last map: %s", e)
+
     def auto_load_database(self):
         """Automatically load database matching pattern RamanLab_Database_*.pkl"""
         import pickle
@@ -912,6 +949,11 @@ class MapAnalysisMainWindow(QMainWindow):
                 
                 self.statusBar().showMessage(f"Loaded {n_spectra:,} spectra{perf_msg}")
                 logger.info(f"Loaded map data with {n_spectra:,} spectra")
+
+                from core.config_manager import ConfigManager
+                _cfg = ConfigManager()
+                _cfg.set('map_analysis.last_map_path', directory)
+                _cfg.set('map_analysis.last_map_type', 'directory')
                 
                 # Initialize integration slider with spectrum midpoint
                 self._initialize_integration_slider()
@@ -989,6 +1031,11 @@ class MapAnalysisMainWindow(QMainWindow):
                 f"({self.map_data.width} × {self.map_data.height})"
             )
             logger.info(f"Loaded single-file map with {len(self.map_data.spectra)} spectra")
+
+            from core.config_manager import ConfigManager
+            _cfg = ConfigManager()
+            _cfg.set('map_analysis.last_map_path', file_path)
+            _cfg.set('map_analysis.last_map_type', 'single_file')
             
             self._initialize_integration_slider()
             
@@ -10796,7 +10843,24 @@ The map is now ready for analysis!"""
                     row[param_name] = self.peak_fitting_results['map_parameters'][param_name][pos_key]
                 else:
                     row[param_name] = np.nan
-                    
+
+            shapes = self.peak_fitting_results['peak_shapes']
+            map_params = self.peak_fitting_results['map_parameters']
+            total_int = 0.0
+            all_valid = True
+            for i, shape in enumerate(shapes, 1):
+                amp = map_params.get(f'P{i}_Amp', {}).get(pos_key, np.nan)
+                wid = map_params.get(f'P{i}_Wid', {}).get(pos_key, np.nan)
+                eta = map_params.get(f'P{i}_Eta', {}).get(pos_key, 0.5)
+                if np.isfinite(amp) and np.isfinite(wid):
+                    ii = compute_integrated_intensity(amp, wid, shape, eta)
+                    row[f'P{i}_IntInt'] = ii
+                    total_int += ii
+                else:
+                    row[f'P{i}_IntInt'] = np.nan
+                    all_valid = False
+            row['Total_IntInt'] = total_int if all_valid else np.nan
+
             if pos_key in self.peak_fitting_results['r_squared']:
                 row['R-Squared'] = self.peak_fitting_results['r_squared'][pos_key]
             else:

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -1036,12 +1036,7 @@ class MapAnalysisMainWindow(QMainWindow):
             _cfg = ConfigManager()
             _cfg.set('map_analysis.last_map_path', file_path)
             _cfg.set('map_analysis.last_map_type', 'single_file')
-            
-            self._initialize_integration_slider()
-            
-            # Update the map display
-            self.update_map()
-            
+
             # Show success message
             QMessageBox.information(
                 self,

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -230,6 +230,7 @@ class MapAnalysisMainWindow(QMainWindow):
             self._clear_map_cache()
             self._initialize_integration_slider()
             self.update_map()
+            self.on_tab_changed(self.tab_widget.currentIndex())
             self.progress_status.hide_progress()
             self.statusBar().showMessage(
                 f"Restored last map: {Path(path).name} "
@@ -950,10 +951,13 @@ class MapAnalysisMainWindow(QMainWindow):
                 self.statusBar().showMessage(f"Loaded {n_spectra:,} spectra{perf_msg}")
                 logger.info(f"Loaded map data with {n_spectra:,} spectra")
 
-                from core.config_manager import ConfigManager
-                _cfg = ConfigManager()
-                _cfg.set('map_analysis.last_map_path', directory)
-                _cfg.set('map_analysis.last_map_type', 'directory')
+                try:
+                    from core.config_manager import ConfigManager
+                    _cfg = ConfigManager()
+                    _cfg.set('map_analysis.last_map_path', directory)
+                    _cfg.set('map_analysis.last_map_type', 'directory')
+                except Exception as cfg_err:
+                    logger.warning("Could not persist last map path: %s", cfg_err)
                 
                 # Initialize integration slider with spectrum midpoint
                 self._initialize_integration_slider()
@@ -1032,10 +1036,13 @@ class MapAnalysisMainWindow(QMainWindow):
             )
             logger.info(f"Loaded single-file map with {len(self.map_data.spectra)} spectra")
 
-            from core.config_manager import ConfigManager
-            _cfg = ConfigManager()
-            _cfg.set('map_analysis.last_map_path', file_path)
-            _cfg.set('map_analysis.last_map_type', 'single_file')
+            try:
+                from core.config_manager import ConfigManager
+                _cfg = ConfigManager()
+                _cfg.set('map_analysis.last_map_path', file_path)
+                _cfg.set('map_analysis.last_map_type', 'single_file')
+            except Exception as cfg_err:
+                logger.warning("Could not persist last map path: %s", cfg_err)
 
             # Show success message
             QMessageBox.information(
@@ -6744,13 +6751,21 @@ All spectra have been processed and cleaned data is now available for analysis."
                 print(f"[PKL LOAD] ✓ Wavenumbers already in correct order")
             
             self.progress_status.hide_progress()
-            
+
             # Initialize integration slider with spectrum midpoint
             self._initialize_integration_slider()
-            
+
             # Update the display
             self.update_map()
-            
+
+            try:
+                from core.config_manager import ConfigManager
+                _cfg = ConfigManager()
+                _cfg.set('map_analysis.last_map_path', file_path)
+                _cfg.set('map_analysis.last_map_type', 'single_file')
+            except Exception as cfg_err:
+                logger.warning("Could not persist last map path: %s", cfg_err)
+
             # Show loading summary
             spectra_count = len(self.map_data.spectra)
             processed_count = sum(1 for s in self.map_data.spectra.values() 
@@ -10828,32 +10843,40 @@ The map is now ready for analysis!"""
         if not file_path:
             return
 
+        shapes = self.peak_fitting_results['peak_shapes']
+        map_params = self.peak_fitting_results['map_parameters']
+        fit_errors = self.peak_fitting_results.get('fit_errors', {})
+        peak_amp_dicts = [map_params.get(f'P{i}_Amp', {}) for i in range(1, len(shapes) + 1)]
+        peak_wid_dicts = [map_params.get(f'P{i}_Wid', {}) for i in range(1, len(shapes) + 1)]
+        peak_eta_dicts = [map_params.get(f'P{i}_Eta', {}) for i in range(1, len(shapes) + 1)]
+
         data = []
         for key, spectrum in self.map_data.spectra.items():
             pos_key = (spectrum.x_pos, spectrum.y_pos)
             row = {'X': spectrum.x_pos, 'Y': spectrum.y_pos}
-            
+
             for param_name in self.peak_fitting_results['param_names']:
-                if pos_key in self.peak_fitting_results['map_parameters'][param_name]:
-                    row[param_name] = self.peak_fitting_results['map_parameters'][param_name][pos_key]
+                if pos_key in map_params[param_name]:
+                    row[param_name] = map_params[param_name][pos_key]
                 else:
                     row[param_name] = np.nan
 
-            shapes = self.peak_fitting_results['peak_shapes']
-            map_params = self.peak_fitting_results['map_parameters']
+            has_fit_error = bool(fit_errors.get(pos_key))
             total_int = 0.0
-            all_valid = True
-            for i, shape in enumerate(shapes, 1):
-                amp = map_params.get(f'P{i}_Amp', {}).get(pos_key, np.nan)
-                wid = map_params.get(f'P{i}_Wid', {}).get(pos_key, np.nan)
-                eta = map_params.get(f'P{i}_Eta', {}).get(pos_key, 0.5)
-                if np.isfinite(amp) and np.isfinite(wid):
+            all_valid = not has_fit_error
+            for i, (shape, amp_dict, wid_dict, eta_dict) in enumerate(
+                zip(shapes, peak_amp_dicts, peak_wid_dicts, peak_eta_dicts), 1
+            ):
+                amp = amp_dict.get(pos_key, np.nan)
+                wid = wid_dict.get(pos_key, np.nan)
+                eta = eta_dict.get(pos_key, 0.5)
+                if has_fit_error or not (np.isfinite(amp) and np.isfinite(wid)):
+                    row[f'P{i}_IntInt'] = np.nan
+                    all_valid = False
+                else:
                     ii = compute_integrated_intensity(amp, wid, shape, eta)
                     row[f'P{i}_IntInt'] = ii
                     total_int += ii
-                else:
-                    row[f'P{i}_IntInt'] = np.nan
-                    all_valid = False
             row['Total_IntInt'] = total_int if all_valid else np.nan
 
             if pos_key in self.peak_fitting_results['r_squared']:
@@ -10861,7 +10884,7 @@ The map is now ready for analysis!"""
             else:
                 row['R-Squared'] = np.nan
 
-            row['Fit Error'] = self.peak_fitting_results.get('fit_errors', {}).get(pos_key, "")
+            row['Fit Error'] = fit_errors.get(pos_key, "")
             row['Fit Warning'] = self.peak_fitting_results.get('fit_warnings', {}).get(pos_key, "")
 
             data.append(row)


### PR DESCRIPTION
## **User description**
## Summary

- **Integrated intensity columns in CSV export**: After running a full map peak fit, the "Export to Batch System" CSV now includes `P{i}_IntInt` (per-peak analytical area) and `Total_IntInt` (sum of all peaks) columns alongside the existing amplitude/center/width parameters.
  - Gaussian: `A × w × √π`
  - Lorentzian: `A × w × π`
  - Pseudo-Voigt: `A × w × ((1-η)·√π + η·π)`
  - Rows with fit errors export `NaN` for all `IntInt` columns.

- **Auto-restore last map on startup**: The Peak Fitting section now remembers the last opened map (saved via `ConfigManager`) and reloads it automatically at startup using `QTimer.singleShot`, so there is no need to re-open the file after restarting the app.

## Test plan

- [ ] Load a Raman map, run Peak Fitting with 1 Gaussian peak, export CSV — verify `P1_IntInt` and `Total_IntInt` columns are present and `P1_IntInt ≈ P1_Amp × P1_Wid × √π`
- [ ] Repeat with 2 peaks — verify `P2_IntInt` present and `Total_IntInt = P1_IntInt + P2_IntInt`
- [ ] Verify rows with fit errors show `NaN` for all `IntInt` columns
- [ ] Load a map, restart the app — verify the same map reloads automatically in the Peak Fitting section
- [ ] Verify app starts cleanly when no previous map exists (first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/timnik82/ramanlab/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds integrated intensity columns to peak-fit CSV exports and auto-restores the last opened map on startup (directories, single-file, and PKL). Also ships a Results Panel plan and hybrid planning docs, switches CI to Python 3.14, and removes duplicate UI updates.

- **New Features**
  - CSV export adds `P{i}_IntInt` and `Total_IntInt` using analytical areas (preserves amplitude sign); writes `NaN` when amplitude/width are invalid or on fit errors.
  - Remembers the last opened map via `ConfigManager` and reloads it on startup; refreshes the active tab; skips restore if the path is missing.
  - Adds `docs/features/*`: Results Panel implementation plan, index README, issue template, and a hybrid planning guide; fixes code-fence language tags.

- **Bug Fixes**
  - Isolated config writes so persistence failures never block map loads.
  - Removed duplicate integration slider initialization and map refresh on single-file map load.

<sup>Written for commit 8a04539e2eeb1b564a2a5be17f0e177d55a12701. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Export peak fit area values and reopen the last map automatically**

### What Changed
- Peak fitting exports now include an integrated intensity value for each peak and a total integrated intensity across all peaks
- The exported area values are calculated from the fitted peak shape, and rows with incomplete fit data leave these values blank
- The app now remembers the last opened map and reloads it when Peak Fitting opens again, so users do not need to pick the same file after restarting

### Impact
`✅ Faster peak fitting exports`
`✅ Fewer repeated file selections after restart`
`✅ Clearer exported fit results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=lUdOri3YA4FSj55ckm9kGsev3DM1O9-KK-TmQT_EiVA&org=timnik82)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
