### PR TITLE
Fix cross-platform PKL map loading

### DIFF
--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -6750,12 +6750,10 @@ All spectra have been processed and cleaned data is now available for analysis."
             self.progress_status.show_progress("Loading map data from PKL...")
             
             # Load from pickle file with module compatibility handling
-            import pickle
-            import sys
-            import types
+            from pkl_utils import CrossPlatformUnpickler
             
             # Create module compatibility mapping
-            class ModuleCompatibilityUnpickler(pickle.Unpickler):
+            class ModuleCompatibilityUnpickler(CrossPlatformUnpickler):
                 def find_class(self, module, name):
                     # Handle old module names that have been renamed
                     if module.startswith('map_analysis_2d_qt6'):
@@ -7409,10 +7407,10 @@ The map is now ready for analysis!"""
         try:
             self.progress_status.show_progress("Loading PKL file...")
             
-            import pickle
+            from pkl_utils import CrossPlatformUnpickler
             
             # Use the same compatibility unpickler as load_map_from_pkl
-            class ModuleCompatibilityUnpickler(pickle.Unpickler):
+            class ModuleCompatibilityUnpickler(CrossPlatformUnpickler):
                 def find_class(self, module, name):
                     if module.startswith('map_analysis_2d_qt6'):
                         new_module = module.replace('map_analysis_2d_qt6', 'map_analysis_2d')

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -7358,7 +7358,7 @@ The map is now ready for analysis!"""
                 self._reset_peak_fitting_state(clear_config=True)
                 if 'cosmic_ray_config' in save_data:
                     self.cosmic_ray_config = save_data['cosmic_ray_config']
-                self.cosmic_ray_manager = SimpleCosmicRayManager(self.cosmic_ray_config)
+                    self.cosmic_ray_manager = SimpleCosmicRayManager(self.cosmic_ray_config)
             else:
                 self.map_data = save_data
                 self._reset_peak_fitting_state(clear_config=True)

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -6747,11 +6747,9 @@ All spectra have been processed and cleaned data is now available for analysis."
         try:
             self.progress_status.show_progress("Loading map data from PKL...")
             
-            from pkl_utils import CrossPlatformUnpickler
+            from pkl_utils import safe_pickle_load
             
-            with open(file_path, 'rb') as f:
-                unpickler = CrossPlatformUnpickler(f)
-                save_data = unpickler.load()
+            save_data = safe_pickle_load(file_path)
             
             # Extract data based on file format
             if isinstance(save_data, dict):
@@ -7346,11 +7344,9 @@ The map is now ready for analysis!"""
         try:
             self.progress_status.show_progress("Loading PKL file...")
             
-            from pkl_utils import CrossPlatformUnpickler
+            from pkl_utils import safe_pickle_load
             
-            with open(file_path, 'rb') as f:
-                unpickler = CrossPlatformUnpickler(f)
-                save_data = unpickler.load()
+            save_data = safe_pickle_load(file_path)
             
             # Extract map data
             if isinstance(save_data, dict) and 'map_data' in save_data:

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -243,9 +243,9 @@ class MapAnalysisMainWindow(QMainWindow):
 
     def auto_load_database(self):
         """Automatically load database matching pattern RamanLab_Database_*.pkl"""
-        import pickle
         import glob
         from pathlib import Path
+        from pkl_utils import safe_pickle_load
         
         # Search in common locations
         search_paths = [
@@ -273,8 +273,7 @@ class MapAnalysisMainWindow(QMainWindow):
             try:
                 logger.info(f"Auto-loading database from: {database_file}")
                 
-                with open(database_file, 'rb') as f:
-                    full_database = pickle.load(f)
+                full_database = safe_pickle_load(database_file)
                 
                 # Filter for plastics only
                 self.database = {}
@@ -331,7 +330,7 @@ class MapAnalysisMainWindow(QMainWindow):
     
     def load_database_file(self):
         """Load Raman database from pickle file and filter for plastics only."""
-        import pickle
+        from pkl_utils import safe_pickle_load
         
         file_path, _ = QFileDialog.getOpenFileName(
             self, "Load Raman Database", "",
@@ -340,8 +339,7 @@ class MapAnalysisMainWindow(QMainWindow):
         
         if file_path:
             try:
-                with open(file_path, 'rb') as f:
-                    full_database = pickle.load(f)
+                full_database = safe_pickle_load(file_path)
                 
                 # Filter for plastics only
                 self.database = {}
@@ -6749,70 +6747,10 @@ All spectra have been processed and cleaned data is now available for analysis."
         try:
             self.progress_status.show_progress("Loading map data from PKL...")
             
-            # Load from pickle file with module compatibility handling
             from pkl_utils import CrossPlatformUnpickler
             
-            # Create module compatibility mapping
-            class ModuleCompatibilityUnpickler(CrossPlatformUnpickler):
-                def find_class(self, module, name):
-                    # Handle old module names that have been renamed
-                    if module.startswith('map_analysis_2d_qt6'):
-                        # Replace old module name with new one
-                        new_module = module.replace('map_analysis_2d_qt6', 'map_analysis_2d')
-                        logger.info(f"PKL Compatibility: Redirecting {module}.{name} -> {new_module}.{name}")
-                        try:
-                            # Try to import the new module
-                            mod = __import__(new_module, fromlist=[name])
-                            result = getattr(mod, name)
-                            logger.info(f"PKL Compatibility: Successfully found {name} in {new_module}")
-                            return result
-                        except (ImportError, AttributeError) as e:
-                            # If new module doesn't have the class, try to find it elsewhere
-                            logger.warning(f"Module compatibility: {module}.{name} -> {new_module}.{name} failed: {e}")
-                            pass
-                    
-                    # Handle other legacy module names
-                    elif module in ['raman_analysis_qt6', 'raman_map_analysis_qt6']:
-                        logger.info(f"PKL Compatibility: Redirecting legacy module {module}.{name}")
-                        # Try to find the class in the new module structure
-                        try:
-                            if name == 'RamanMapData':
-                                from map_analysis_2d.core.file_io import RamanMapData
-                                logger.info(f"PKL Compatibility: Found {name} in file_io module")
-                                return RamanMapData
-                            elif name in ['CosmicRayConfig', 'SimpleCosmicRayManager']:
-                                from map_analysis_2d.core.cosmic_ray_detection import CosmicRayConfig, SimpleCosmicRayManager
-                                result = CosmicRayConfig if name == 'CosmicRayConfig' else SimpleCosmicRayManager
-                                logger.info(f"PKL Compatibility: Found {name} in cosmic_ray_detection module")
-                                return result
-                            elif name == 'SpectrumData':
-                                from map_analysis_2d.core.spectrum_data import SpectrumData
-                                logger.info(f"PKL Compatibility: Found {name} in spectrum_data module")
-                                return SpectrumData
-                        except ImportError as e:
-                            logger.warning(f"Could not find {name} in new module structure: {e}")
-                            pass
-                    
-                    # Handle other known compatibility issues
-                    elif module == 'raman_map_data' and name == 'RamanMapData':
-                        logger.info(f"PKL Compatibility: Redirecting {module}.{name} to file_io module")
-                        # Import from the correct location
-                        from map_analysis_2d.core.file_io import RamanMapData
-                        return RamanMapData
-                    elif module == 'cosmic_ray_detection' and name in ['CosmicRayConfig', 'SimpleCosmicRayManager']:
-                        logger.info(f"PKL Compatibility: Redirecting {module}.{name} to cosmic_ray_detection module")
-                        # Import from the correct location
-                        from map_analysis_2d.core.cosmic_ray_detection import CosmicRayConfig, SimpleCosmicRayManager
-                        if name == 'CosmicRayConfig':
-                            return CosmicRayConfig
-                        else:
-                            return SimpleCosmicRayManager
-                    
-                    # Fall back to default behavior
-                    return super().find_class(module, name)
-            
             with open(file_path, 'rb') as f:
-                unpickler = ModuleCompatibilityUnpickler(f)
+                unpickler = CrossPlatformUnpickler(f)
                 save_data = unpickler.load()
             
             # Extract data based on file format
@@ -6892,6 +6830,7 @@ All spectra have been processed and cleaned data is now available for analysis."
             self._initialize_integration_slider()
 
             # Update the display
+            self._clear_map_cache()
             self.update_map()
 
             try:
@@ -7409,20 +7348,8 @@ The map is now ready for analysis!"""
             
             from pkl_utils import CrossPlatformUnpickler
             
-            # Use the same compatibility unpickler as load_map_from_pkl
-            class ModuleCompatibilityUnpickler(CrossPlatformUnpickler):
-                def find_class(self, module, name):
-                    if module.startswith('map_analysis_2d_qt6'):
-                        new_module = module.replace('map_analysis_2d_qt6', 'map_analysis_2d')
-                        try:
-                            mod = __import__(new_module, fromlist=[name])
-                            return getattr(mod, name)
-                        except (ImportError, AttributeError):
-                            pass
-                    return super().find_class(module, name)
-            
             with open(file_path, 'rb') as f:
-                unpickler = ModuleCompatibilityUnpickler(f)
+                unpickler = CrossPlatformUnpickler(f)
                 save_data = unpickler.load()
             
             # Extract map data
@@ -7431,6 +7358,7 @@ The map is now ready for analysis!"""
                 self._reset_peak_fitting_state(clear_config=True)
                 if 'cosmic_ray_config' in save_data:
                     self.cosmic_ray_config = save_data['cosmic_ray_config']
+                self.cosmic_ray_manager = SimpleCosmicRayManager(self.cosmic_ray_config)
             else:
                 self.map_data = save_data
                 self._reset_peak_fitting_state(clear_config=True)

--- a/pkl_utils.py
+++ b/pkl_utils.py
@@ -8,10 +8,31 @@ import os
 import sys
 import pickle
 import logging
+import pathlib
 from pathlib import Path
 
 # Set up logging
 logger = logging.getLogger(__name__)
+
+
+class CrossPlatformUnpickler(pickle.Unpickler):
+    """Unpickler that can load concrete pathlib paths from other operating systems."""
+
+    def find_class(self, module, name):
+        if module == "pathlib":
+            if name == "WindowsPath" and os.name != "nt":
+                logger.info("PKL Compatibility: Loading pathlib.WindowsPath as PureWindowsPath")
+                return pathlib.PureWindowsPath
+            if name == "PosixPath" and os.name == "nt":
+                logger.info("PKL Compatibility: Loading pathlib.PosixPath as PurePosixPath")
+                return pathlib.PurePosixPath
+
+        return super().find_class(module, name)
+
+
+def cross_platform_pickle_load(file_obj):
+    """Load pickle data while tolerating OS-specific pathlib objects."""
+    return CrossPlatformUnpickler(file_obj).load()
 
 def ensure_module_path():
     """
@@ -142,7 +163,7 @@ def safe_pickle_load(file_path, ensure_path=True):
     
     try:
         with open(file_path, 'rb') as f:
-            data = pickle.load(f)
+            data = cross_platform_pickle_load(f)
         logger.info(f"Successfully loaded PKL file: {file_path}")
         return data
         

--- a/pkl_utils.py
+++ b/pkl_utils.py
@@ -27,6 +27,38 @@ class CrossPlatformUnpickler(pickle.Unpickler):
                 logger.info("PKL Compatibility: Loading pathlib.PosixPath as PurePosixPath")
                 return pathlib.PurePosixPath
 
+        if module.startswith("map_analysis_2d_qt6"):
+            new_module = module.replace("map_analysis_2d_qt6", "map_analysis_2d")
+            logger.info("PKL Compatibility: Redirecting %s.%s -> %s.%s", module, name, new_module, name)
+            try:
+                mod = __import__(new_module, fromlist=[name])
+                return getattr(mod, name)
+            except (ImportError, AttributeError) as e:
+                logger.warning("Module compatibility: %s.%s -> %s.%s failed: %s", module, name, new_module, name, e)
+
+        if module in ["raman_analysis_qt6", "raman_map_analysis_qt6"]:
+            logger.info("PKL Compatibility: Redirecting legacy module %s.%s", module, name)
+            try:
+                if name == "RamanMapData":
+                    from map_analysis_2d.core.file_io import RamanMapData
+                    return RamanMapData
+                if name in ["CosmicRayConfig", "SimpleCosmicRayManager"]:
+                    from map_analysis_2d.core.cosmic_ray_detection import CosmicRayConfig, SimpleCosmicRayManager
+                    return CosmicRayConfig if name == "CosmicRayConfig" else SimpleCosmicRayManager
+                if name == "SpectrumData":
+                    from map_analysis_2d.core.spectrum_data import SpectrumData
+                    return SpectrumData
+            except ImportError as e:
+                logger.warning("Could not find %s in new module structure: %s", name, e)
+
+        if module == "raman_map_data" and name == "RamanMapData":
+            from map_analysis_2d.core.file_io import RamanMapData
+            return RamanMapData
+
+        if module == "cosmic_ray_detection" and name in ["CosmicRayConfig", "SimpleCosmicRayManager"]:
+            from map_analysis_2d.core.cosmic_ray_detection import CosmicRayConfig, SimpleCosmicRayManager
+            return CosmicRayConfig if name == "CosmicRayConfig" else SimpleCosmicRayManager
+
         return super().find_class(module, name)
 
 
@@ -139,6 +171,9 @@ def get_example_data_paths():
 def safe_pickle_load(file_path, ensure_path=True):
     """
     Safely load a pickle file with proper module path resolution.
+
+    Only load PKL files from trusted sources. Pickle deserialization can execute
+    code embedded in the file; this helper provides compatibility, not sandboxing.
     
     Args:
         file_path (str or Path): Path to the pickle file

--- a/test_pkl_utils_cross_platform.py
+++ b/test_pkl_utils_cross_platform.py
@@ -1,0 +1,36 @@
+import pathlib
+import os
+import pickle
+import tempfile
+import unittest
+
+from pkl_utils import safe_pickle_load
+
+
+class CrossPlatformPickleTests(unittest.TestCase):
+    def test_safe_pickle_load_handles_windows_path_on_non_windows(self):
+        payload = b"cpathlib\nWindowsPath\np0\n(VC:/data/map/source.txt\np1\ntp2\nRp3\n."
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pkl_file = pathlib.Path(tmp_dir) / "windows_path.pkl"
+            pkl_file.write_bytes(payload)
+
+            loaded = safe_pickle_load(pkl_file)
+
+        self.assertEqual(loaded, pathlib.PureWindowsPath("C:/data/map/source.txt"))
+
+    @unittest.skipIf(os.name == "nt", "PosixPath is only native on POSIX systems")
+    def test_safe_pickle_load_preserves_native_posix_path(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pkl_file = pathlib.Path(tmp_dir) / "posix_path.pkl"
+            expected = pathlib.Path("/tmp/map/source.txt")
+            pkl_file.write_bytes(pickle.dumps(expected))
+
+            loaded = safe_pickle_load(pkl_file)
+
+        self.assertIs(type(loaded), pathlib.PosixPath)
+        self.assertEqual(loaded, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_pkl_utils_cross_platform.py
+++ b/test_pkl_utils_cross_platform.py
@@ -1,10 +1,11 @@
 import pathlib
+import io
 import os
 import pickle
 import tempfile
 import unittest
 
-from pkl_utils import safe_pickle_load
+from pkl_utils import CrossPlatformUnpickler, safe_pickle_load
 
 
 class CrossPlatformPickleTests(unittest.TestCase):
@@ -30,6 +31,20 @@ class CrossPlatformPickleTests(unittest.TestCase):
 
         self.assertIs(type(loaded), pathlib.PosixPath)
         self.assertEqual(loaded, expected)
+
+    def test_cross_platform_unpickler_redirects_legacy_map_classes(self):
+        try:
+            from map_analysis_2d.core.file_io import RamanMapData
+        except ModuleNotFoundError as e:
+            if e.name == "numpy":
+                self.skipTest("RamanMapData import requires numpy")
+            raise
+
+        unpickler = CrossPlatformUnpickler(io.BytesIO())
+
+        loaded_class = unpickler.find_class("raman_map_data", "RamanMapData")
+
+        self.assertIs(loaded_class, RamanMapData)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix cross-platform PKL loading by mapping OS-specific `pathlib` paths and centralizing legacy module remaps during unpickling. PKL map and database files created on Windows or POSIX now load reliably.

- **Bug Fixes**
  - Added `CrossPlatformUnpickler` that maps `pathlib.WindowsPath` → `pathlib.PureWindowsPath` on non-Windows and `pathlib.PosixPath` → `pathlib.PurePosixPath` on Windows; also redirects legacy modules (`map_analysis_2d_qt6` → `map_analysis_2d`, `raman_*_qt6`, `raman_map_data`, `cosmic_ray_detection`).
  - Replaced UI-specific loaders with shared `safe_pickle_load` in both PKL map paths and database loads.
  - Cleared map cache after load and re-initialized `SimpleCosmicRayManager` when restoring `cosmic_ray_config` to avoid stale state.
  - Added tests for Windows-path pickles on non-Windows, preserving native POSIX paths, and redirecting `RamanMapData` from legacy modules.

<sup>Written for commit 5642852692288def8d3c6121de77f51710a02931. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Load saved maps and databases from different operating systems without breaking restore**

### What Changed
- Map and database files now load even when they were saved on a different operating system, including Windows and POSIX paths.
- Older saved files that refer to renamed map-related modules now restore instead of failing to open.
- Loading a saved map now refreshes the displayed data and clears stale cached map content.
- Restoring a saved map also rebuilds the cosmic ray tools so the loaded state matches the file.
- Added tests for cross-platform paths, native POSIX paths, and legacy map file names.

### Impact
`✅ Fewer map load failures with shared PKL files`
`✅ Works when saves move between Windows and Linux/macOS`
`✅ Restored maps show the correct current data`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=lR0zfbZhnpPF0ADcQkFI8bJHj9JH6mlmsLagBzGFo0k&org=timnik82)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
