### PR TITLE
Make left control panel layout fully responsive

### DIFF
--- a/map_analysis_2d/ui/base_widgets.py
+++ b/map_analysis_2d/ui/base_widgets.py
@@ -68,72 +68,51 @@ class ParameterGroupBox(QGroupBox, SafeWidgetMixin):
         self.layout.setColumnStretch(0, 0)  # Don't stretch label column
         self.layout.setColumnStretch(1, 1)  # Stretch control column
         self.row_count = 0
-        
+
+    def _make_label(self, text: str) -> QLabel:
+        w = QLabel(f"{text}:")
+        w.setMaximumWidth(90)
+        w.setWordWrap(True)
+        return w
+
+    def _add_row(self, label: str, control: QWidget, min_height: int = 0) -> None:
+        control.setMinimumWidth(60)
+        if min_height:
+            control.setMinimumHeight(min_height)
+        control.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.layout.addWidget(self._make_label(label), self.row_count, 0, Qt.AlignmentFlag.AlignTop)
+        self.layout.addWidget(control, self.row_count, 1)
+        self.row_count += 1
+
     def add_double_spinbox(self, label: str, min_val: float, max_val: float,
                           value: float, step: float = 1.0) -> QDoubleSpinBox:
-        """Add a double spinbox parameter."""
-        label_widget = QLabel(f"{label}:")
-        label_widget.setMaximumWidth(90)
-        label_widget.setWordWrap(True)
         spinbox = QDoubleSpinBox()
         spinbox.setRange(min_val, max_val)
         spinbox.setValue(value)
         spinbox.setSingleStep(step)
-        spinbox.setMinimumWidth(60)
-        spinbox.setMinimumHeight(30)
-        spinbox.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-
-        self.layout.addWidget(label_widget, self.row_count, 0, Qt.AlignmentFlag.AlignTop)
-        self.layout.addWidget(spinbox, self.row_count, 1)
-        self.row_count += 1
-
+        self._add_row(label, spinbox, min_height=30)
         return spinbox
 
     def add_spinbox(self, label: str, min_val: int, max_val: int,
                    value: int) -> QSpinBox:
-        """Add an integer spinbox parameter."""
-        label_widget = QLabel(f"{label}:")
-        label_widget.setMaximumWidth(90)
-        label_widget.setWordWrap(True)
         spinbox = QSpinBox()
         spinbox.setRange(min_val, max_val)
         spinbox.setValue(value)
-        spinbox.setMinimumWidth(60)
-        spinbox.setMinimumHeight(30)
-        spinbox.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-
-        self.layout.addWidget(label_widget, self.row_count, 0, Qt.AlignmentFlag.AlignTop)
-        self.layout.addWidget(spinbox, self.row_count, 1)
-        self.row_count += 1
-
+        self._add_row(label, spinbox, min_height=30)
         return spinbox
-    
+
     def add_checkbox(self, label: str, checked: bool = False) -> QCheckBox:
-        """Add a checkbox parameter."""
         checkbox = QCheckBox(label)
         checkbox.setChecked(checked)
-        # Note: QCheckBox doesn't have setWordWrap, text wrapping is handled automatically
-        
         self.layout.addWidget(checkbox, self.row_count, 0, 1, 2)
         self.row_count += 1
-        
         return checkbox
-    
+
     def add_combobox(self, label: str, items: list, current_index: int = 0) -> QComboBox:
-        """Add a combobox parameter."""
-        label_widget = QLabel(f"{label}:")
-        label_widget.setMaximumWidth(90)
-        label_widget.setWordWrap(True)
         combobox = QComboBox()
         combobox.addItems(items)
         combobox.setCurrentIndex(current_index)
-        combobox.setMinimumWidth(60)
-        combobox.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-
-        self.layout.addWidget(label_widget, self.row_count, 0, Qt.AlignmentFlag.AlignTop)
-        self.layout.addWidget(combobox, self.row_count, 1)
-        self.row_count += 1
-
+        self._add_row(label, combobox)
         return combobox
 
 

--- a/map_analysis_2d/ui/base_widgets.py
+++ b/map_analysis_2d/ui/base_widgets.py
@@ -10,7 +10,7 @@ from typing import Optional, Any
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QGroupBox,
     QPushButton, QLabel, QCheckBox, QSpinBox, QDoubleSpinBox,
-    QComboBox, QLineEdit, QScrollArea, QProgressBar
+    QComboBox, QLineEdit, QScrollArea, QProgressBar, QSizePolicy
 )
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
@@ -69,43 +69,43 @@ class ParameterGroupBox(QGroupBox, SafeWidgetMixin):
         self.layout.setColumnStretch(1, 1)  # Stretch control column
         self.row_count = 0
         
-    def add_double_spinbox(self, label: str, min_val: float, max_val: float, 
+    def add_double_spinbox(self, label: str, min_val: float, max_val: float,
                           value: float, step: float = 1.0, width: int = 120) -> QDoubleSpinBox:
         """Add a double spinbox parameter."""
         label_widget = QLabel(f"{label}:")
-        label_widget.setMaximumWidth(90)  # Constrain label width
-        label_widget.setWordWrap(True)  # Allow text wrapping
+        label_widget.setMaximumWidth(90)
+        label_widget.setWordWrap(True)
         spinbox = QDoubleSpinBox()
         spinbox.setRange(min_val, max_val)
         spinbox.setValue(value)
         spinbox.setSingleStep(step)
-        spinbox.setMaximumWidth(width)  # Increased default width
-        spinbox.setMinimumWidth(80)  # Increased minimum width for better usability
-        spinbox.setMinimumHeight(30)  # Add minimum height for better touch targets
-        
+        spinbox.setMinimumWidth(60)
+        spinbox.setMinimumHeight(30)
+        spinbox.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
         self.layout.addWidget(label_widget, self.row_count, 0, Qt.AlignmentFlag.AlignTop)
-        self.layout.addWidget(spinbox, self.row_count, 1, Qt.AlignmentFlag.AlignLeft)
+        self.layout.addWidget(spinbox, self.row_count, 1)
         self.row_count += 1
-        
+
         return spinbox
-    
-    def add_spinbox(self, label: str, min_val: int, max_val: int, 
+
+    def add_spinbox(self, label: str, min_val: int, max_val: int,
                    value: int, width: int = 120) -> QSpinBox:
         """Add an integer spinbox parameter."""
         label_widget = QLabel(f"{label}:")
-        label_widget.setMaximumWidth(90)  # Constrain label width
-        label_widget.setWordWrap(True)  # Allow text wrapping
+        label_widget.setMaximumWidth(90)
+        label_widget.setWordWrap(True)
         spinbox = QSpinBox()
         spinbox.setRange(min_val, max_val)
         spinbox.setValue(value)
-        spinbox.setMaximumWidth(width)  # Increased default width
-        spinbox.setMinimumWidth(80)  # Increased minimum width for better usability
-        spinbox.setMinimumHeight(30)  # Add minimum height for better touch targets
-        
+        spinbox.setMinimumWidth(60)
+        spinbox.setMinimumHeight(30)
+        spinbox.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
         self.layout.addWidget(label_widget, self.row_count, 0, Qt.AlignmentFlag.AlignTop)
-        self.layout.addWidget(spinbox, self.row_count, 1, Qt.AlignmentFlag.AlignLeft)
+        self.layout.addWidget(spinbox, self.row_count, 1)
         self.row_count += 1
-        
+
         return spinbox
     
     def add_checkbox(self, label: str, checked: bool = False) -> QCheckBox:
@@ -122,18 +122,18 @@ class ParameterGroupBox(QGroupBox, SafeWidgetMixin):
     def add_combobox(self, label: str, items: list, current_index: int = 0, width: int = 120) -> QComboBox:
         """Add a combobox parameter."""
         label_widget = QLabel(f"{label}:")
-        label_widget.setMaximumWidth(90)  # Constrain label width 
-        label_widget.setWordWrap(True)  # Allow text wrapping
+        label_widget.setMaximumWidth(90)
+        label_widget.setWordWrap(True)
         combobox = QComboBox()
         combobox.addItems(items)
         combobox.setCurrentIndex(current_index)
-        combobox.setMaximumWidth(width)  # Control combobox width
-        combobox.setMinimumWidth(80)  # Minimum width for readability
-        
+        combobox.setMinimumWidth(60)
+        combobox.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
         self.layout.addWidget(label_widget, self.row_count, 0, Qt.AlignmentFlag.AlignTop)
-        self.layout.addWidget(combobox, self.row_count, 1, Qt.AlignmentFlag.AlignLeft)
+        self.layout.addWidget(combobox, self.row_count, 1)
         self.row_count += 1
-        
+
         return combobox
 
 

--- a/map_analysis_2d/ui/base_widgets.py
+++ b/map_analysis_2d/ui/base_widgets.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import (
     QPushButton, QLabel, QCheckBox, QSpinBox, QDoubleSpinBox,
     QComboBox, QLineEdit, QScrollArea, QProgressBar, QSizePolicy
 )
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, Signal, QSize
 from PySide6.QtGui import QFont
 
 logger = logging.getLogger(__name__)
@@ -173,6 +173,22 @@ class ButtonGroup(QWidget):
         return buttons
 
 
+class _ContractibleContent(QWidget):
+    """Inner widget for ScrollableControlPanel that lets the splitter shrink it
+    below the layout's natural minimum width.
+
+    QScrollArea with setWidgetResizable(True) refuses to size the inner widget
+    smaller than its minimumSizeHint, which by default is the layout's minimum
+    size — so the panel scrolls horizontally instead of contracting. By clamping
+    the hint's width to 0 we let the splitter narrow the panel; children with
+    Expanding size policies are then squeezed by the layout to fit.
+    """
+
+    def minimumSizeHint(self) -> QSize:
+        sh = super().minimumSizeHint()
+        return QSize(0, sh.height())
+
+
 class ScrollableControlPanel(QScrollArea, SafeWidgetMixin):
     """
     Scrollable control panel that can dynamically update its content.
@@ -185,16 +201,17 @@ class ScrollableControlPanel(QScrollArea, SafeWidgetMixin):
         
         # Configure scroll area
         self.setWidgetResizable(True)
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        # Content should contract with the splitter, not introduce a horizontal scrollbar.
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         # Allow resizing by setting maximum and minimum widths more flexibly
         self.setMaximumWidth(max_width)
-        self.setMinimumWidth(200)  # Reasonable minimum width
+        self.setMinimumWidth(180)
         # Set preferred width but allow resizing
         self.resize(280, self.height())
-        
+
         # Create main widget and layout
-        self.main_widget = QWidget()
+        self.main_widget = _ContractibleContent()
         self.main_layout = QVBoxLayout(self.main_widget)
         self.main_layout.setSpacing(6)
         self.main_layout.setContentsMargins(4, 4, 4, 4)

--- a/map_analysis_2d/ui/base_widgets.py
+++ b/map_analysis_2d/ui/base_widgets.py
@@ -70,7 +70,7 @@ class ParameterGroupBox(QGroupBox, SafeWidgetMixin):
         self.row_count = 0
         
     def add_double_spinbox(self, label: str, min_val: float, max_val: float,
-                          value: float, step: float = 1.0, width: int = 120) -> QDoubleSpinBox:
+                          value: float, step: float = 1.0) -> QDoubleSpinBox:
         """Add a double spinbox parameter."""
         label_widget = QLabel(f"{label}:")
         label_widget.setMaximumWidth(90)
@@ -90,7 +90,7 @@ class ParameterGroupBox(QGroupBox, SafeWidgetMixin):
         return spinbox
 
     def add_spinbox(self, label: str, min_val: int, max_val: int,
-                   value: int, width: int = 120) -> QSpinBox:
+                   value: int) -> QSpinBox:
         """Add an integer spinbox parameter."""
         label_widget = QLabel(f"{label}:")
         label_widget.setMaximumWidth(90)
@@ -119,7 +119,7 @@ class ParameterGroupBox(QGroupBox, SafeWidgetMixin):
         
         return checkbox
     
-    def add_combobox(self, label: str, items: list, current_index: int = 0, width: int = 120) -> QComboBox:
+    def add_combobox(self, label: str, items: list, current_index: int = 0) -> QComboBox:
         """Add a combobox parameter."""
         label_widget = QLabel(f"{label}:")
         label_widget.setMaximumWidth(90)

--- a/map_analysis_2d/ui/base_widgets.py
+++ b/map_analysis_2d/ui/base_widgets.py
@@ -185,7 +185,7 @@ class ScrollableControlPanel(QScrollArea, SafeWidgetMixin):
         
         # Configure scroll area
         self.setWidgetResizable(True)
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         # Allow resizing by setting maximum and minimum widths more flexibly
         self.setMaximumWidth(max_width)

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -147,7 +147,7 @@ class MapViewControlPanel(BaseControlPanel):
         self.range_width_spin.setValue(100.0)
         self.range_width_spin.setSingleStep(25.0)
         self.range_width_spin.setToolTip("Width of integration range")
-        self.range_width_spin.setMaximumWidth(100)
+        self.range_width_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         width_layout.addWidget(self.range_width_spin)
 
         width_widget = QWidget()
@@ -1155,20 +1155,15 @@ class MLControlPanel(BaseControlPanel):
         self.clustering_method_combo.addItems([
             "K-Means", "Gaussian Mixture", "DBSCAN", "Hierarchical"
         ])
-        self.clustering_method_combo.setMaximumWidth(150)
+        self.clustering_method_combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.clustering_method_combo.setToolTip("Choose clustering algorithm")
         algo_layout.addWidget(self.clustering_method_combo)
         
         # Parameters - condensed
         cluster_params = ParameterGroupBox("Settings")
         self.n_clusters_spin = cluster_params.add_spinbox("Clusters", 2, 20, 3)
-        self.n_clusters_spin.setMaximumWidth(70)
-        
         self.eps_spin = cluster_params.add_double_spinbox("Eps", 0.1, 10.0, 0.5, 0.1)
-        self.eps_spin.setMaximumWidth(70)
-        
         self.min_samples_spin = cluster_params.add_spinbox("Min Samples", 2, 20, 5)
-        self.min_samples_spin.setMaximumWidth(70)
         
         # Training action - condensed
         action_group = QGroupBox("🚀 Run")
@@ -1492,10 +1487,12 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.min_wavenumber_spin = QDoubleSpinBox()
         self.min_wavenumber_spin.setRange(0, 4000)
         self.min_wavenumber_spin.setValue(400)
-        
+        self.min_wavenumber_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
         self.max_wavenumber_spin = QDoubleSpinBox()
         self.max_wavenumber_spin.setRange(0, 4000)
         self.max_wavenumber_spin.setValue(600)
+        self.max_wavenumber_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         
         self.min_wavenumber_spin.valueChanged.connect(self.fitting_config_changed.emit)
         self.max_wavenumber_spin.valueChanged.connect(self.fitting_config_changed.emit)
@@ -1515,18 +1512,17 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.num_peaks_spin = QSpinBox()
         self.num_peaks_spin.setRange(1, 5)
         self.num_peaks_spin.setValue(1)
+        self.num_peaks_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.num_peaks_spin.valueChanged.connect(self._rebuild_peaks_ui)
         self.num_peaks_spin.valueChanged.connect(self.fitting_config_changed.emit)
         num_peaks_layout.addWidget(self.num_peaks_spin)
         peaks_layout.addLayout(num_peaks_layout)
         
-        # Scroll area for dynamic peak inputs
-        self.peaks_scroll = QScrollArea()
-        self.peaks_scroll.setWidgetResizable(True)
+        # Container for dynamic peak inputs (no scroll — outer panel scrolls)
         self.peaks_scroll_content = QWidget()
         self.peaks_scroll_layout = QVBoxLayout(self.peaks_scroll_content)
-        self.peaks_scroll.setWidget(self.peaks_scroll_content)
-        peaks_layout.addWidget(self.peaks_scroll)
+        self.peaks_scroll_layout.setContentsMargins(0, 0, 0, 0)
+        peaks_layout.addWidget(self.peaks_scroll_content)
         
         self.layout.addWidget(peaks_group)
         
@@ -1604,6 +1600,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
             spin.setRange(range_min, range_max)
             spin.setValue(default_val)
             spin.setSingleStep(step)
+            spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             grid_layout.addWidget(spin, row_idx, col_idx)
 
             if col_idx == 1:
@@ -1639,14 +1636,18 @@ class MapPeakFittingControlPanel(BaseControlPanel):
             shape_layout = QHBoxLayout()
             shape_combo = QComboBox()
             shape_combo.addItems(["Lorentzian", "Gaussian", "Pseudo-Voigt"])
+            shape_combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             shape_layout.addWidget(QLabel("Shape:"))
             shape_layout.addWidget(shape_combo)
-            shape_layout.addStretch()
             layout.addLayout(shape_layout)
             self.shape_combos.append(shape_combo)
 
             # Initial parameters and bounds grid
             grid = QGridLayout()
+            grid.setColumnStretch(0, 0)
+            grid.setColumnStretch(1, 1)
+            grid.setColumnStretch(2, 1)
+            grid.setColumnStretch(3, 1)
             grid.addWidget(QLabel("Init"), 0, 1)
             grid.addWidget(QLabel("Min"), 0, 2)
             grid.addWidget(QLabel("Max"), 0, 3)

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -488,7 +488,7 @@ class DimensionalityReductionControlPanel(BaseControlPanel):
         # PCA Parameters
         pca_params_group = ParameterGroupBox("PCA Parameters")
         self.pca_n_components_spin = pca_params_group.add_spinbox(
-            "Components", 2, 50, 5, width=60)
+            "Components", 2, 50, 5)
         self.pca_n_components_spin.setToolTip("Number of principal components to extract")
         pca_layout.addWidget(pca_params_group)
         
@@ -525,27 +525,27 @@ class DimensionalityReductionControlPanel(BaseControlPanel):
         # NMF Basic Parameters
         nmf_params_group = ParameterGroupBox("NMF Parameters")
         self.nmf_n_components_spin = nmf_params_group.add_spinbox(
-            "Components", 2, 20, 5, width=60)
+            "Components", 2, 20, 5)
         self.nmf_n_components_spin.setToolTip("Number of NMF components to extract")
-        
+
         self.nmf_max_iter_spin = nmf_params_group.add_spinbox(
-            "Max Iterations", 100, 1000, 200, width=60)
+            "Max Iterations", 100, 1000, 200)
         self.nmf_max_iter_spin.setToolTip("Maximum iterations for NMF convergence")
-        
+
         self.nmf_random_state_spin = nmf_params_group.add_spinbox(
-            "Random State", 0, 999, 42, width=60)
+            "Random State", 0, 999, 42)
         self.nmf_random_state_spin.setToolTip("Random seed for reproducible results")
         nmf_layout.addWidget(nmf_params_group)
         
         # NMF Advanced Parameters
         nmf_advanced_group = ParameterGroupBox("Advanced Options")
         self.nmf_batch_size_spin = nmf_advanced_group.add_spinbox(
-            "Batch Size", 500, 10000, 2000, width=80)
+            "Batch Size", 500, 10000, 2000)
         self.nmf_batch_size_spin.setToolTip("Maximum samples for fitting (larger datasets)")
-        
+
         # Solver selection
         self.nmf_solver_combo = nmf_advanced_group.add_combobox(
-            "Solver", ["mu", "cd"], 0, width=100)
+            "Solver", ["mu", "cd"], 0)
         self.nmf_solver_combo.setToolTip("mu: Multiplicative Update (stable), cd: Coordinate Descent (faster)")
         nmf_layout.addWidget(nmf_advanced_group)
         

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -1488,11 +1488,13 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.min_wavenumber_spin.setRange(0, 4000)
         self.min_wavenumber_spin.setValue(400)
         self.min_wavenumber_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.min_wavenumber_spin.setMinimumWidth(50)
 
         self.max_wavenumber_spin = QDoubleSpinBox()
         self.max_wavenumber_spin.setRange(0, 4000)
         self.max_wavenumber_spin.setValue(600)
         self.max_wavenumber_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.max_wavenumber_spin.setMinimumWidth(50)
         
         self.min_wavenumber_spin.valueChanged.connect(self.fitting_config_changed.emit)
         self.max_wavenumber_spin.valueChanged.connect(self.fitting_config_changed.emit)
@@ -1513,6 +1515,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.num_peaks_spin.setRange(1, 5)
         self.num_peaks_spin.setValue(1)
         self.num_peaks_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.num_peaks_spin.setMinimumWidth(50)
         self.num_peaks_spin.valueChanged.connect(self._rebuild_peaks_ui)
         self.num_peaks_spin.valueChanged.connect(self.fitting_config_changed.emit)
         num_peaks_layout.addWidget(self.num_peaks_spin)
@@ -1531,6 +1534,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         viz_layout = QVBoxLayout(viz_group)
         
         self.visualization_combo = QComboBox()
+        self.visualization_combo.setMinimumWidth(60)
         self.visualization_combo.currentTextChanged.connect(
             lambda text: self.visualization_parameter_changed.emit(text)
         )
@@ -1544,20 +1548,24 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         
         self.test_fit_btn = StandardButton("Test Fit Current Pixel")
         self.test_fit_btn.setToolTip("Click a pixel on the map, then click this to test your initial parameters.")
+        self.test_fit_btn.setMinimumWidth(0)
         self.test_fit_btn.clicked.connect(self.test_fit_requested.emit)
         actions_layout.addWidget(self.test_fit_btn)
-        
+
         self.run_fit_btn = PrimaryButton("Run Map Fitting")
+        self.run_fit_btn.setMinimumWidth(0)
         self.run_fit_btn.clicked.connect(self.run_map_fitting_requested.emit)
         actions_layout.addWidget(self.run_fit_btn)
-        
+
         self.export_batch_btn = StandardButton("Export to Batch System")
+        self.export_batch_btn.setMinimumWidth(0)
         self.export_batch_btn.setEnabled(False)
         self.export_batch_btn.clicked.connect(self.export_batch_requested.emit)
         actions_layout.addWidget(self.export_batch_btn)
 
         self.export_results_csv_btn = StandardButton("Export Results CSV")
         self.export_results_csv_btn.setToolTip("Export one row per pixel with peak parameters")
+        self.export_results_csv_btn.setMinimumWidth(0)
         self.export_results_csv_btn.setEnabled(False)
         self.export_results_csv_btn.clicked.connect(self.export_results_csv_requested.emit)
         actions_layout.addWidget(self.export_results_csv_btn)
@@ -1600,7 +1608,10 @@ class MapPeakFittingControlPanel(BaseControlPanel):
             spin.setRange(range_min, range_max)
             spin.setValue(default_val)
             spin.setSingleStep(step)
-            spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+            # Ignored horizontal policy: lets the param grid columns shrink to
+            # whatever the splitter allows without inflating the panel's minimum.
+            spin.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed)
+            spin.setMinimumWidth(40)
             grid_layout.addWidget(spin, row_idx, col_idx)
 
             if col_idx == 1:
@@ -1637,6 +1648,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
             shape_combo = QComboBox()
             shape_combo.addItems(["Lorentzian", "Gaussian", "Pseudo-Voigt"])
             shape_combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+            shape_combo.setMinimumWidth(60)
             shape_layout.addWidget(QLabel("Shape:"))
             shape_layout.addWidget(shape_combo)
             layout.addLayout(shape_layout)

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QPushButton, 
     QLabel, QCheckBox, QComboBox, QLineEdit, QListWidget, QTabWidget,
     QTextEdit, QSlider, QDoubleSpinBox, QSizePolicy, QFrame,
-    QSpinBox, QScrollArea, QFormLayout, QGridLayout
+    QSpinBox, QFormLayout, QGridLayout
 )
 from PySide6.QtCore import Signal, Qt, QTimer
 
@@ -1685,6 +1685,8 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self._update_visualization_combo()
         
     def _on_shape_changed(self, text, idx):
+        if idx >= len(self.eta_labels):
+            return
         is_pv = text == "Pseudo-Voigt"
         self.eta_labels[idx].setVisible(is_pv)
         for spin in self.eta_spins[idx].values():

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -534,8 +534,8 @@ class MapAnalysisMainWindow(QMainWindow):
         main_layout.addWidget(self.splitter)
         
         # Left panel for controls (remove max_width constraint to allow resizing)
-        self.controls_panel = ScrollableControlPanel(max_width=500)  # Increased max width
-        self.controls_panel.setMinimumWidth(200)  # Set minimum width to prevent too small
+        self.controls_panel = ScrollableControlPanel(max_width=700)
+        self.controls_panel.setMinimumWidth(280)
         self.create_permanent_controls()
         self.splitter.addWidget(self.controls_panel)
         
@@ -543,7 +543,7 @@ class MapAnalysisMainWindow(QMainWindow):
         self.create_visualization_panel(self.splitter)
         
         # Set initial splitter proportions (left panel ~20%, right panel ~80%)
-        self.splitter.setSizes([300, 1200])
+        self.splitter.setSizes([420, 1080])
         
         # Make the splitter handle more responsive
         self.splitter.setOpaqueResize(True)  # Show content while dragging

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -125,7 +125,9 @@ class SimpleMapData:
 
 class MapAnalysisMainWindow(QMainWindow):
     """Main window for 2D Raman map analysis."""
-    
+
+    DEFAULT_CONTROL_PANEL_WIDTH = 420
+
     def __init__(self, parent=None):
         super().__init__(parent)
         
@@ -543,7 +545,7 @@ class MapAnalysisMainWindow(QMainWindow):
         self.create_visualization_panel(self.splitter)
         
         # Set initial splitter proportions (left panel ~20%, right panel ~80%)
-        self.splitter.setSizes([420, 1080])
+        self.splitter.setSizes([self.DEFAULT_CONTROL_PANEL_WIDTH, 1080])
         
         # Make the splitter handle more responsive
         self.splitter.setOpaqueResize(True)  # Show content while dragging
@@ -1014,7 +1016,7 @@ class MapAnalysisMainWindow(QMainWindow):
         """Reset the splitter panel layout to default proportions."""
         # Reset to default sizes (control panel ~20%, visualization ~80%)
         total_width = self.width()
-        control_width = 300
+        control_width = self.DEFAULT_CONTROL_PANEL_WIDTH
         viz_width = total_width - control_width
         self.splitter.setSizes([control_width, viz_width])
         self.statusBar().showMessage("Panel layout reset to default", 2000)


### PR DESCRIPTION
## **User description**
- Remove inner QScrollArea from Peaks Configuration section so content expands naturally instead of being clipped
- Set equal column stretch on peak parameter grid so Init/Min/Max spinboxes share available width proportionally
- Set Expanding size policy on all spinboxes and combos in ParameterGroupBox helpers and throughout MapPeakFittingControlPanel
- Remove hardcoded setMaximumWidth constraints on input widgets
- Increase initial splitter width (300→420px) and max panel width (500→700px) to give the panel enough room by default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the left control panel fully responsive so inputs scale with space and don’t clip. The panel now contracts with the splitter instead of showing a horizontal scrollbar; Reset Layout restores the 420px default width.

- **Refactors**
  - Removed inner scroll area in Peaks Configuration; outer panel contracts with the splitter (no horizontal scrollbar).
  - Added a contractible scroll content widget; set dense grid spinboxes to QSizePolicy.Ignored; tightened minimum widths on inputs; action buttons set to 0 min width.
  - Standardized sizing: set Expanding on spinboxes/combos, removed setMaximumWidth, extracted _make_label/_add_row helpers, and removed an unused QScrollArea import.
  - Equalized Init/Min/Max column stretch in the peak parameter grid. Widths: initial splitter 420px, max panel 700px, min panel 280px; Reset Layout uses DEFAULT_CONTROL_PANEL_WIDTH (420px). Guarded _on_shape_changed against stale indexes.

- **Bug Fixes**
  - Removed leftover width= kwargs in PCA/NMF controls to match updated helpers, fixing a TypeError when building the tab.

<sup>Written for commit de108b4b24842d17fe4c7fb01852cdd624f52cdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Make the left control panel resize cleanly and keep peak settings visible**

### What Changed
- The left control panel now shrinks with the splitter instead of clipping content, and it shows a scrollbar when the panel becomes too narrow.
- Peak fitting fields, wavenumber inputs, and algorithm selectors now expand to use available space instead of staying fixed-width.
- The peak parameter grid now shares space evenly across Init, Min, and Max values, so peak settings stay readable in narrow layouts.
- Reset Layout now restores the actual default panel width, and peak-shape changes no longer fail after the peak list is rebuilt.

### Impact
`✅ Fewer clipped controls in the left panel`
`✅ Better peak-setting visibility in narrow windows`
`✅ Reset Layout returns to the expected panel width`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=8rkfGOFatbGjZfln7mY5YoSmiSTiW_gMLx-_u1f0FeM&org=timnik82)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
