### PR TITLE
Persist Map Peak Fitting panel settings across sessions

### DIFF
--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -1784,6 +1784,11 @@ class MapPeakFittingControlPanel(BaseControlPanel):
             for spin in (self.min_wavenumber_spin, self.max_wavenumber_spin, self.num_peaks_spin):
                 spin.blockSignals(False)
 
+        # Signals were blocked while setting num_peaks, so the UI didn't rebuild
+        # automatically. Rebuild now so shape_combos / amp_spins etc. match shapes.
+        if len(self.shape_combos) != len(shapes):
+            self._rebuild_peaks_ui()
+
         param_index = 0
         initial_params = config.get("initial_params", [])
         lower_bounds, upper_bounds = config.get("bounds", ([], []))

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -1784,15 +1784,10 @@ class MapPeakFittingControlPanel(BaseControlPanel):
             for spin in (self.min_wavenumber_spin, self.max_wavenumber_spin, self.num_peaks_spin):
                 spin.blockSignals(False)
 
-        # Signals were blocked while setting num_peaks, so the UI didn't rebuild
-        # automatically. Rebuild now so shape_combos / amp_spins etc. match shapes.
-        if len(self.shape_combos) != len(shapes):
-            self._rebuild_peaks_ui()
-
-        param_index = 0
+        # Validate before rebuilding: a rebuild resets all peaks to defaults, so
+        # bailing out after that would leave the panel in a partially-restored state.
         initial_params = config.get("initial_params", [])
         lower_bounds, upper_bounds = config.get("bounds", ([], []))
-
         expected_param_count = sum(4 if shape == "Pseudo-Voigt" else 3 for shape in shapes)
         if len(initial_params) < expected_param_count:
             logger.warning("Skipping peak fitting config restore: initial parameters are incomplete")
@@ -1800,6 +1795,13 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         if len(lower_bounds) < expected_param_count or len(upper_bounds) < expected_param_count:
             logger.warning("Skipping peak fitting config restore: parameter bounds are incomplete")
             return
+
+        # Signals were blocked while setting num_peaks, so the UI didn't rebuild
+        # automatically. Rebuild now so shape_combos / amp_spins etc. match shapes.
+        if len(self.shape_combos) != len(shapes):
+            self._rebuild_peaks_ui()
+
+        param_index = 0
 
         for peak_index, shape in enumerate(shapes):
             self.shape_combos[peak_index].setCurrentText(shape)

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -187,6 +187,10 @@ class MapAnalysisMainWindow(QMainWindow):
         self.peak_fitting_results = None
         self.peak_fitting_config = None
         self.peak_fitting_worker = None
+        # Last-used Map Peak Fitting panel settings, persisted across sessions.
+        # Used as a fallback when peak_fitting_config has been reset (e.g. after
+        # loading a new map) so the user's configured peaks survive map reloads.
+        self._saved_peak_fitting_config = self._load_saved_peak_fitting_config()
         
         # Performance optimization for large datasets
         self._map_cache = {}  # Cache computed maps to avoid recomputation
@@ -838,6 +842,11 @@ class MapAnalysisMainWindow(QMainWindow):
         """Set up the status bar."""
         self.progress_status = ProgressStatusWidget()
         self.statusBar().addWidget(self.progress_status, 1)
+
+    def closeEvent(self, event):
+        """Persist the active peak fitting panel state so it survives the next launch."""
+        self._cache_peak_fitting_config_from_panel()
+        super().closeEvent(event)
         
     def on_tab_changed(self, index: int):
         """Handle tab changes to update control panel."""
@@ -854,9 +863,10 @@ class MapAnalysisMainWindow(QMainWindow):
             control_panel.fitting_config_changed.connect(control_panel.results_panel.clear)
             self.controls_panel.add_section("peak_fitting_controls", control_panel)
 
-            if self.peak_fitting_config is not None:
+            restore_config = self.peak_fitting_config or self._saved_peak_fitting_config
+            if restore_config is not None:
                 # Restores all spinboxes and combo selection; fires visualization_parameter_changed once
-                control_panel.set_peak_configuration(self.peak_fitting_config)
+                control_panel.set_peak_configuration(restore_config)
 
             pending = getattr(self, "_pending_peak_fitting_stats", None)
             if pending is not None:
@@ -1539,8 +1549,47 @@ class MapAnalysisMainWindow(QMainWindow):
             try:
                 panel_config = control_panel.get_peak_configuration()
                 self.peak_fitting_config = merge_peak_fitting_configuration(self.peak_fitting_config, panel_config)
+                self._save_peak_fitting_config_to_disk(self.peak_fitting_config)
             except ValueError as exc:
                 logger.debug("Skipping invalid cached peak fitting configuration: %s", exc)
+
+    def _load_saved_peak_fitting_config(self):
+        """Return the last-used Map Peak Fitting config from disk, if any."""
+        try:
+            from core.config_manager import ConfigManager
+            cfg = ConfigManager()
+            saved = cfg.get('map_analysis.last_peak_fitting_config')
+            if not isinstance(saved, dict) or not saved.get('shapes'):
+                return None
+            region = saved.get('region')
+            if isinstance(region, list) and len(region) == 2:
+                saved['region'] = tuple(region)
+            bounds = saved.get('bounds')
+            if isinstance(bounds, list) and len(bounds) == 2:
+                saved['bounds'] = (list(bounds[0]), list(bounds[1]))
+            return saved
+        except Exception as e:
+            logger.debug("Could not load saved peak fitting config: %s", e)
+            return None
+
+    def _save_peak_fitting_config_to_disk(self, config):
+        """Write the latest Map Peak Fitting config so the next session restores it."""
+        if not config:
+            return
+        try:
+            serializable = dict(config)
+            region = serializable.get('region')
+            if isinstance(region, tuple):
+                serializable['region'] = list(region)
+            bounds = serializable.get('bounds')
+            if isinstance(bounds, tuple) and len(bounds) == 2:
+                serializable['bounds'] = [list(bounds[0]), list(bounds[1])]
+            from core.config_manager import ConfigManager
+            cfg = ConfigManager()
+            cfg.set('map_analysis.last_peak_fitting_config', serializable)
+            self._saved_peak_fitting_config = config
+        except Exception as e:
+            logger.debug("Could not save peak fitting config: %s", e)
 
     def get_current_peak_fitting_control_panel(self):
         """Get the current peak fitting control panel if it exists."""

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -1556,17 +1556,41 @@ class MapAnalysisMainWindow(QMainWindow):
     def _load_saved_peak_fitting_config(self):
         """Return the last-used Map Peak Fitting config from disk, if any."""
         try:
-            from core.config_manager import ConfigManager
-            cfg = ConfigManager()
+            from core.config_manager import get_config_manager
+            cfg = get_config_manager()
             saved = cfg.get('map_analysis.last_peak_fitting_config')
-            if not isinstance(saved, dict) or not saved.get('shapes'):
+            if not isinstance(saved, dict):
                 return None
+
+            shapes = saved.get('shapes')
+            if not isinstance(shapes, list) or not shapes:
+                return None
+
             region = saved.get('region')
             if isinstance(region, list) and len(region) == 2:
-                saved['region'] = tuple(region)
+                region = tuple(region)
+                saved['region'] = region
+            if not (isinstance(region, tuple) and len(region) == 2):
+                return None
+
             bounds = saved.get('bounds')
             if isinstance(bounds, list) and len(bounds) == 2:
-                saved['bounds'] = (list(bounds[0]), list(bounds[1]))
+                bounds = (list(bounds[0]), list(bounds[1]))
+                saved['bounds'] = bounds
+            if not (isinstance(bounds, tuple) and len(bounds) == 2
+                    and isinstance(bounds[0], list) and isinstance(bounds[1], list)):
+                return None
+
+            initial_params = saved.get('initial_params')
+            if not isinstance(initial_params, list):
+                return None
+            if not (len(initial_params) == len(bounds[0]) == len(bounds[1])):
+                return None
+
+            expected_param_count = sum(4 if s == "Pseudo-Voigt" else 3 for s in shapes)
+            if len(initial_params) < expected_param_count:
+                return None
+
             return saved
         except Exception as e:
             logger.debug("Could not load saved peak fitting config: %s", e)
@@ -1576,6 +1600,9 @@ class MapAnalysisMainWindow(QMainWindow):
         """Write the latest Map Peak Fitting config so the next session restores it."""
         if not config:
             return
+        # Update the in-memory fallback eagerly so a disk write failure can't
+        # leave _saved_peak_fitting_config stale relative to the latest panel state.
+        self._saved_peak_fitting_config = config
         try:
             serializable = dict(config)
             region = serializable.get('region')
@@ -1584,12 +1611,11 @@ class MapAnalysisMainWindow(QMainWindow):
             bounds = serializable.get('bounds')
             if isinstance(bounds, tuple) and len(bounds) == 2:
                 serializable['bounds'] = [list(bounds[0]), list(bounds[1])]
-            from core.config_manager import ConfigManager
-            cfg = ConfigManager()
+            from core.config_manager import get_config_manager
+            cfg = get_config_manager()
             cfg.set('map_analysis.last_peak_fitting_config', serializable)
-            self._saved_peak_fitting_config = config
         except Exception as e:
-            logger.debug("Could not save peak fitting config: %s", e)
+            logger.warning("Could not save peak fitting config: %s", e)
 
     def get_current_peak_fitting_control_panel(self):
         """Get the current peak fitting control panel if it exists."""


### PR DESCRIPTION
## **User description**
The Map Peak Fitting control panel now remembers its last-used settings (fitting region, peak count, shapes, init values, bounds, visualization parameter) and restores them when the app starts. The config is written to ConfigManager whenever the panel state is cached (tab change, app close) and read back into a saved-config fallback so it survives peak_fitting_config resets that happen when a new map is loaded.

Also fix set_peak_configuration to rebuild the dynamic peak rows when the saved peak count differs from the panel's current count — signals on num_peaks_spin are blocked during restore, so _rebuild_peaks_ui needed an explicit call.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Map Peak Fitting panel settings across sessions and map reloads by saving to `ConfigManager` and restoring on app start. Add schema validation and a safer restore flow to prevent partial resets and stale state.

- **New Features**
  - Persist last-used settings (region, peak count, shapes, initial params, bounds, visualization parameter).
  - Save to `map_analysis.last_peak_fitting_config` on tab change and app close; restore on launch and when opening the panel.
  - Use saved config as a fallback after loading a new map.

- **Bug Fixes**
  - Validate saved config structure before restore; ignore malformed/legacy configs and rebuild peak rows only after validation.
  - Update the in-memory fallback before disk write and use `get_config_manager()` to avoid stale state and redundant disk reads.

<sup>Written for commit 8d93b67d433f9b781a4e435a0598b07e6a14554c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Keep Map Peak Fitting settings after app restart and map reloads**

### What Changed
- The Map Peak Fitting panel now restores the last used region, peak count, shapes, initial values, bounds, and visualization choice when the panel opens
- Those settings are saved when the user switches tabs or closes the app, so they carry over to the next session
- When restoring a saved peak count, the peak rows now rebuild correctly so the visible controls match the saved shapes

### Impact
`✅ Settings survive app restarts`
`✅ Peak fitting setup survives map reloads`
`✅ Fewer mismatched peak controls`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=5aYkkzk8ZrGgD22lTghzbkzi_WrL6S-tcUmWn-c1N_8&org=timnik82)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
