### PR TITLE
Persist Map View settings across sessions + fix fitting_config_changed TypeError

### DIFF
--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -516,6 +516,8 @@ class MapViewControlPanel(BaseControlPanel):
         finally:
             for w in widgets_to_block:
                 w.blockSignals(False)
+            self._on_integration_mode_changed(self.integration_mode.currentText())
+            self._on_auto_scale_toggled(self.auto_scale_cb.isChecked())
             if self.integration_mode.currentText() == "Custom Range":
                 self._emit_wavenumber_range()
             if not self.auto_scale_cb.isChecked():

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -518,6 +518,8 @@ class MapViewControlPanel(BaseControlPanel):
                 w.blockSignals(False)
             if self.integration_mode.currentText() == "Custom Range":
                 self._emit_wavenumber_range()
+            if not self.auto_scale_cb.isChecked():
+                self._emit_intensity_scaling()
 
 
 class DimensionalityReductionControlPanel(BaseControlPanel):

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -466,39 +466,58 @@ class MapViewControlPanel(BaseControlPanel):
             'center_wavenumber': self.center_wavenumber_slider.value(),
             'range_width': self.range_width_spin.value(),
             'auto_scale': self.auto_scale_cb.isChecked(),
+            'vmin': self.vmin_spin.value(),
+            'vmax': self.vmax_spin.value(),
             'cosmic_ray_enabled': self.cosmic_ray_enabled_cb.isChecked(),
             'cr_threshold': self.threshold_spin.value(),
             'cr_neighbor_ratio': self.neighbor_ratio_spin.value(),
         }
 
     def restore_view_settings(self, settings: dict):
-        mode = settings.get('integration_mode')
-        if mode in ("Full Spectrum", "Custom Range"):
-            self.integration_mode.setCurrentText(mode)
+        widgets_to_block = [
+            self.integration_mode, self.center_wavenumber_slider,
+            self.range_width_spin, self.feature_combo,
+            self.use_processed_cb, self.auto_scale_cb,
+            self.cosmic_ray_enabled_cb, self.threshold_spin,
+            self.neighbor_ratio_spin, self.vmin_spin, self.vmax_spin,
+        ]
+        for w in widgets_to_block:
+            w.blockSignals(True)
+        try:
+            mode = settings.get('integration_mode')
+            if mode in ("Full Spectrum", "Custom Range"):
+                self.integration_mode.setCurrentText(mode)
 
-        center = settings.get('center_wavenumber')
-        if center is not None:
-            lo = self.center_wavenumber_slider.minimum()
-            hi = self.center_wavenumber_slider.maximum()
-            self.center_wavenumber_slider.setValue(max(lo, min(hi, int(center))))
+            center = settings.get('center_wavenumber')
+            if center is not None:
+                lo = self.center_wavenumber_slider.minimum()
+                hi = self.center_wavenumber_slider.maximum()
+                self.center_wavenumber_slider.setValue(max(lo, min(hi, int(center))))
 
-        for key, widget in [('range_width', self.range_width_spin),
-                             ('cr_threshold', self.threshold_spin),
-                             ('cr_neighbor_ratio', self.neighbor_ratio_spin)]:
-            val = settings.get(key)
-            if val is not None:
-                widget.setValue(float(val))
+            for key, widget in [('range_width', self.range_width_spin),
+                                 ('vmin', self.vmin_spin),
+                                 ('vmax', self.vmax_spin),
+                                 ('cr_threshold', self.threshold_spin),
+                                 ('cr_neighbor_ratio', self.neighbor_ratio_spin)]:
+                val = settings.get(key)
+                if val is not None:
+                    widget.setValue(float(val))
 
-        feature = settings.get('feature')
-        if feature and self.feature_combo.findText(feature) >= 0:
-            self.feature_combo.setCurrentText(feature)
+            feature = settings.get('feature')
+            if feature and self.feature_combo.findText(feature) >= 0:
+                self.feature_combo.setCurrentText(feature)
 
-        for attr, key in [('use_processed_cb', 'use_processed'),
-                          ('auto_scale_cb', 'auto_scale'),
-                          ('cosmic_ray_enabled_cb', 'cosmic_ray_enabled')]:
-            val = settings.get(key)
-            if val is not None:
-                getattr(self, attr).setChecked(bool(val))
+            for attr, key in [('use_processed_cb', 'use_processed'),
+                               ('auto_scale_cb', 'auto_scale'),
+                               ('cosmic_ray_enabled_cb', 'cosmic_ray_enabled')]:
+                val = settings.get(key)
+                if val is not None:
+                    getattr(self, attr).setChecked(bool(val))
+        finally:
+            for w in widgets_to_block:
+                w.blockSignals(False)
+            if self.integration_mode.currentText() == "Custom Range":
+                self._emit_wavenumber_range()
 
 
 class DimensionalityReductionControlPanel(BaseControlPanel):

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -458,6 +458,53 @@ class MapViewControlPanel(BaseControlPanel):
             
             self.center_wavenumber_slider.setTickInterval(tick_interval)
 
+    def get_view_settings(self) -> dict:
+        return {
+            'feature': self.feature_combo.currentText(),
+            'use_processed': self.use_processed_cb.isChecked(),
+            'integration_mode': self.integration_mode.currentText(),
+            'center_wavenumber': self.center_wavenumber_slider.value(),
+            'range_width': self.range_width_spin.value(),
+            'auto_scale': self.auto_scale_cb.isChecked(),
+            'cosmic_ray_enabled': self.cosmic_ray_enabled_cb.isChecked(),
+            'cr_threshold': self.threshold_spin.value(),
+            'cr_neighbor_ratio': self.neighbor_ratio_spin.value(),
+        }
+
+    def restore_view_settings(self, settings: dict):
+        mode = settings.get('integration_mode')
+        if mode in ("Full Spectrum", "Custom Range"):
+            self.integration_mode.setCurrentText(mode)
+
+        center = settings.get('center_wavenumber')
+        if center is not None:
+            lo = self.center_wavenumber_slider.minimum()
+            hi = self.center_wavenumber_slider.maximum()
+            self.center_wavenumber_slider.setValue(max(lo, min(hi, int(center))))
+
+        width = settings.get('range_width')
+        if width is not None:
+            self.range_width_spin.setValue(float(width))
+
+        feature = settings.get('feature')
+        if feature and self.feature_combo.findText(feature) >= 0:
+            self.feature_combo.setCurrentText(feature)
+
+        for attr, key in [('use_processed_cb', 'use_processed'),
+                          ('auto_scale_cb', 'auto_scale'),
+                          ('cosmic_ray_enabled_cb', 'cosmic_ray_enabled')]:
+            val = settings.get(key)
+            if val is not None:
+                getattr(self, attr).setChecked(bool(val))
+
+        threshold = settings.get('cr_threshold')
+        if threshold is not None:
+            self.threshold_spin.setValue(float(threshold))
+
+        neighbor_ratio = settings.get('cr_neighbor_ratio')
+        if neighbor_ratio is not None:
+            self.neighbor_ratio_spin.setValue(float(neighbor_ratio))
+
 
 class DimensionalityReductionControlPanel(BaseControlPanel):
     """Combined control panel for PCA and NMF analysis."""
@@ -1496,8 +1543,8 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.max_wavenumber_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.max_wavenumber_spin.setMinimumWidth(50)
         
-        self.min_wavenumber_spin.valueChanged.connect(self.fitting_config_changed.emit)
-        self.max_wavenumber_spin.valueChanged.connect(self.fitting_config_changed.emit)
+        self.min_wavenumber_spin.valueChanged.connect(lambda _: self.fitting_config_changed.emit())
+        self.max_wavenumber_spin.valueChanged.connect(lambda _: self.fitting_config_changed.emit())
 
         region_layout.addWidget(QLabel("Min Wavenumber (cm⁻¹):"))
         region_layout.addWidget(self.min_wavenumber_spin)
@@ -1517,7 +1564,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.num_peaks_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.num_peaks_spin.setMinimumWidth(50)
         self.num_peaks_spin.valueChanged.connect(self._rebuild_peaks_ui)
-        self.num_peaks_spin.valueChanged.connect(self.fitting_config_changed.emit)
+        self.num_peaks_spin.valueChanged.connect(lambda _: self.fitting_config_changed.emit())
         num_peaks_layout.addWidget(self.num_peaks_spin)
         peaks_layout.addLayout(num_peaks_layout)
         

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -482,9 +482,12 @@ class MapViewControlPanel(BaseControlPanel):
             hi = self.center_wavenumber_slider.maximum()
             self.center_wavenumber_slider.setValue(max(lo, min(hi, int(center))))
 
-        width = settings.get('range_width')
-        if width is not None:
-            self.range_width_spin.setValue(float(width))
+        for key, widget in [('range_width', self.range_width_spin),
+                             ('cr_threshold', self.threshold_spin),
+                             ('cr_neighbor_ratio', self.neighbor_ratio_spin)]:
+            val = settings.get(key)
+            if val is not None:
+                widget.setValue(float(val))
 
         feature = settings.get('feature')
         if feature and self.feature_combo.findText(feature) >= 0:
@@ -496,14 +499,6 @@ class MapViewControlPanel(BaseControlPanel):
             val = settings.get(key)
             if val is not None:
                 getattr(self, attr).setChecked(bool(val))
-
-        threshold = settings.get('cr_threshold')
-        if threshold is not None:
-            self.threshold_spin.setValue(float(threshold))
-
-        neighbor_ratio = settings.get('cr_neighbor_ratio')
-        if neighbor_ratio is not None:
-            self.neighbor_ratio_spin.setValue(float(neighbor_ratio))
 
 
 class DimensionalityReductionControlPanel(BaseControlPanel):

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -1632,10 +1632,7 @@ class MapAnalysisMainWindow(QMainWindow):
         return None
 
     def _get_current_map_view_panel(self):
-        for name, section in self.controls_panel.sections.items():
-            if name == "map_controls":
-                return section['widget']
-        return None
+        return self.get_current_map_control_panel()
 
     def _cache_map_view_settings_from_panel(self):
         cp = self._get_current_map_view_panel()

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -924,32 +924,33 @@ class MapAnalysisMainWindow(QMainWindow):
             
             self.controls_panel.add_section("map_controls", control_panel)
 
-            saved_view = self._load_map_view_settings()
-            if saved_view:
-                control_panel.restore_view_settings(saved_view)
-
             # Update template status in map control panel
             self.update_map_template_status()
-            
+
             # Always check for classification results and add them to the new control panel
             if hasattr(self, 'classification_results'):
                 logger.info("Found classification results, adding to new map control panel...")
                 self.update_map_features_with_classification()
-            
+
             # Also check for clustering results
             if hasattr(self, 'ml_results') and self.ml_results.get('type') == 'unsupervised':
                 logger.info("Found clustering results, adding to new map control panel...")
                 self.update_map_features_with_clustering()
-            
+
             # Also check for NMF results
             if hasattr(self, 'nmf_analyzer') and hasattr(self.nmf_analyzer, 'nmf') and self.nmf_analyzer.nmf is not None:
                 logger.info("Found NMF results, adding to new map control panel...")
                 self.update_map_features_with_nmf()
-            
+
             # Also check for template results
             if hasattr(self, 'template_fitting_results'):
                 logger.info("Found template fitting results, adding to new map control panel...")
                 self.update_map_features_with_templates()
+
+            # Restore after all dynamic features are populated so saved feature names are findable
+            saved_view = self._load_map_view_settings()
+            if saved_view:
+                control_panel.restore_view_settings(saved_view)
             
         elif index == self._get_template_tab_index():
             control_panel = TemplateControlPanel()

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -846,11 +846,13 @@ class MapAnalysisMainWindow(QMainWindow):
     def closeEvent(self, event):
         """Persist the active peak fitting panel state so it survives the next launch."""
         self._cache_peak_fitting_config_from_panel()
+        self._cache_map_view_settings_from_panel()
         super().closeEvent(event)
         
     def on_tab_changed(self, index: int):
         """Handle tab changes to update control panel."""
         self._cache_peak_fitting_config_from_panel()
+        self._cache_map_view_settings_from_panel()
         self.controls_panel.clear_dynamic_sections()
         
         if index == self._get_peak_fitting_tab_index():
@@ -921,7 +923,11 @@ class MapAnalysisMainWindow(QMainWindow):
             control_panel.fit_templates_to_map_requested.connect(self.fit_templates)
             
             self.controls_panel.add_section("map_controls", control_panel)
-            
+
+            saved_view = self._load_map_view_settings()
+            if saved_view:
+                control_panel.restore_view_settings(saved_view)
+
             # Update template status in map control panel
             self.update_map_template_status()
             
@@ -1623,6 +1629,24 @@ class MapAnalysisMainWindow(QMainWindow):
             if name == "peak_fitting_controls":
                 return section['widget']
         return None
+
+    def _get_current_map_view_panel(self):
+        for name, section in self.controls_panel.sections.items():
+            if name == "map_controls":
+                return section['widget']
+        return None
+
+    def _cache_map_view_settings_from_panel(self):
+        cp = self._get_current_map_view_panel()
+        if cp is None:
+            return
+        from core.config_manager import get_config_manager
+        get_config_manager().set('map_analysis.map_view_settings', cp.get_view_settings())
+
+    def _load_map_view_settings(self):
+        from core.config_manager import get_config_manager
+        val = get_config_manager().get('map_analysis.map_view_settings')
+        return val if isinstance(val, dict) else None
 
     def _get_peak_fitting_configuration(self):
         """Get the current peak fitting configuration from the UI or cached state."""

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -1648,9 +1648,13 @@ class MapAnalysisMainWindow(QMainWindow):
             logger.warning("Could not save map view settings: %s", exc)
 
     def _load_map_view_settings(self):
-        from core.config_manager import get_config_manager
-        val = get_config_manager().get('map_analysis.map_view_settings')
-        return val if isinstance(val, dict) else None
+        try:
+            from core.config_manager import get_config_manager
+            val = get_config_manager().get('map_analysis.map_view_settings')
+            return val if isinstance(val, dict) else None
+        except Exception as exc:
+            logger.warning("Could not load map view settings: %s", exc)
+            return None
 
     def _get_peak_fitting_configuration(self):
         """Get the current peak fitting configuration from the UI or cached state."""

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -1641,8 +1641,11 @@ class MapAnalysisMainWindow(QMainWindow):
         cp = self._get_current_map_view_panel()
         if cp is None:
             return
-        from core.config_manager import get_config_manager
-        get_config_manager().set('map_analysis.map_view_settings', cp.get_view_settings())
+        try:
+            from core.config_manager import get_config_manager
+            get_config_manager().set('map_analysis.map_view_settings', cp.get_view_settings())
+        except Exception as exc:
+            logger.warning("Could not save map view settings: %s", exc)
 
     def _load_map_view_settings(self):
         from core.config_manager import get_config_manager


### PR DESCRIPTION
## **User description**
## Summary

- **Session persistence for Map View panel**: Every time the user switched to the Map View tab, the panel was recreated with defaults — losing the spectral integration range, feature selection, display options, and cosmic ray settings they had configured. This PR adds `get_view_settings()` / `restore_view_settings()` to `MapViewControlPanel`, mirroring the existing peak fitting persistence pattern. Settings are saved on tab switch and on app close, and restored when the panel is recreated.
- **Fix `fitting_config_changed` TypeError**: The `fitting_config_changed = Signal()` (zero-arg) was connected directly to `QDoubleSpinBox.valueChanged` and `QSpinBox.valueChanged`, which emit the new value as an argument. This caused a `TypeError` logged on every spinbox change. Fixed by wrapping with `lambda _:` to drop the argument.

## What changed

| File | Change |
|------|--------|
| `map_analysis_2d/ui/control_panels.py` | Added `get_view_settings()` and `restore_view_settings()` to `MapViewControlPanel`; fixed 3 signal connections |
| `map_analysis_2d/ui/main_window.py` | Added `_get_current_map_view_panel()`, `_cache_map_view_settings_from_panel()`, `_load_map_view_settings()`; hooked into `closeEvent` and `on_tab_changed` |

## Settings persisted
- Integration mode (Full Spectrum / Custom Range), center wavenumber, range width
- Feature selection (guarded — only restored if the feature exists in the combo on next load)
- Use Processed Data checkbox, Auto Scale checkbox
- Cosmic ray enabled, threshold, neighbor ratio

## Test plan
- [ ] Open app → go to Map View → set Custom Range integration, pick a non-default wavenumber center and width
- [ ] Switch to another tab (triggers save), then close and reopen
- [ ] Navigate to Map View → integration settings should be restored
- [ ] Confirm no `TypeError: fitting_config_changed()` in the log when changing peak fitting spinboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Map View settings across tab changes and app restarts, and fix a TypeError from mismatched signal signatures in peak fitting controls. vmin/vmax are now remembered and applied on restore, and Map View toggles (Custom Range visibility and Auto Scale) update correctly after settings are restored.

- **New Features**
  - Added get/restore methods to the Map View panel; saves on tab switch and app close, and restores after the panel is recreated and dynamic features are loaded.
  - Persisted: integration mode/range (center, width), feature (if present), processed data, auto-scale, vmin/vmax, and cosmic ray enabled/threshold/neighbor ratio.

- **Bug Fixes**
  - Wrapped spinbox valueChanged with lambda so the zero-arg fitting_config_changed emits without errors; restore blocks signals to avoid redundant updates, emits the range once if Custom Range is active, applies vmin/vmax when Auto Scale is off, explicitly updates UI state after restore, and guards both save and load paths against config IO errors.
  - Removed duplicate map panel lookup; now delegates to get_current_map_control_panel for a single source of truth.

<sup>Written for commit 41dec06f5bc257417c4e9167e979c2a290e171d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Remember Map View settings between sessions and stop peak fitting errors**

### What Changed
- Map View now restores the last used feature, integration mode, wavenumber range, display options, and cosmic ray settings when you return to it or reopen the app
- The current Map View settings are saved when you switch tabs or close the app, so users do not lose their setup
- Changing peak fitting spin boxes no longer triggers a TypeError in the background

### Impact
`✅ Restored Map View setup after restart`
`✅ Fewer lost analysis settings`
`✅ Clearer peak fitting interactions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
