### PR TITLE
Add loaded map filename indicator

### DIFF
--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -243,6 +243,7 @@ class MapAnalysisMainWindow(QMainWindow):
             self._initialize_integration_slider()
             self.update_map()
             self.on_tab_changed(self.tab_widget.currentIndex())
+            self._set_loaded_map_indicator(path, kind)
             self.progress_status.hide_progress()
             self.statusBar().showMessage(
                 f"Restored last map: {Path(path).name} "
@@ -257,6 +258,29 @@ class MapAnalysisMainWindow(QMainWindow):
         """Return True when a saved map path should be restored via pickle loading."""
         path_obj = Path(path)
         return kind == 'pkl' or path_obj.suffix.lower() in {'.pkl', '.pickle'}
+
+    def _set_loaded_map_indicator(self, path=None, kind=None):
+        """Update the persistent status bar label for the loaded map source."""
+        if not hasattr(self, 'loaded_map_label'):
+            return
+
+        if not path:
+            self.loaded_map_label.setText("Map: none")
+            self.loaded_map_label.setToolTip("No map loaded")
+            return
+
+        path_text = str(path)
+        try:
+            path_obj = Path(path_text)
+            display_name = path_obj.name
+        except (TypeError, ValueError):
+            display_name = ""
+
+        if not display_name:
+            display_name = "unknown"
+
+        self.loaded_map_label.setText(f"Map: {display_name}")
+        self.loaded_map_label.setToolTip(path_text)
 
     def _load_map_data_from_pickle(self, file_path):
         """Load map data from a saved pickle file, including legacy formats."""
@@ -842,6 +866,9 @@ class MapAnalysisMainWindow(QMainWindow):
         """Set up the status bar."""
         self.progress_status = ProgressStatusWidget()
         self.statusBar().addWidget(self.progress_status, 1)
+        self.loaded_map_label = QLabel("Map: none")
+        self.loaded_map_label.setToolTip("No map loaded")
+        self.statusBar().addPermanentWidget(self.loaded_map_label)
 
     def closeEvent(self, event):
         """Persist the active peak fitting panel state so it survives the next launch."""
@@ -1058,6 +1085,7 @@ class MapAnalysisMainWindow(QMainWindow):
                     perf_msg = ""
                 
                 self.statusBar().showMessage(f"Loaded {n_spectra:,} spectra{perf_msg}")
+                self._set_loaded_map_indicator(directory, 'directory')
                 logger.info(f"Loaded map data with {n_spectra:,} spectra")
 
                 try:
@@ -1143,6 +1171,7 @@ class MapAnalysisMainWindow(QMainWindow):
                 f"Loaded {len(self.map_data.spectra)} spectra from single file "
                 f"({self.map_data.width} × {self.map_data.height})"
             )
+            self._set_loaded_map_indicator(file_path, 'single_file')
             logger.info(f"Loaded single-file map with {len(self.map_data.spectra)} spectra")
 
             try:
@@ -6960,6 +6989,7 @@ The map is now ready for analysis!"""
             QMessageBox.information(self, "Load Successful", summary_text)
             
             self.statusBar().showMessage(f"PKL map loaded: {spectra_count} spectra")
+            self._set_loaded_map_indicator(file_path, 'pkl')
             
         except Exception as e:
             self.progress_status.hide_progress()

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -243,7 +243,7 @@ class MapAnalysisMainWindow(QMainWindow):
             self._initialize_integration_slider()
             self.update_map()
             self.on_tab_changed(self.tab_widget.currentIndex())
-            self._set_loaded_map_indicator(path, kind)
+            self._set_loaded_map_indicator(path)
             self.progress_status.hide_progress()
             self.statusBar().showMessage(
                 f"Restored last map: {Path(path).name} "
@@ -259,7 +259,7 @@ class MapAnalysisMainWindow(QMainWindow):
         path_obj = Path(path)
         return kind == 'pkl' or path_obj.suffix.lower() in {'.pkl', '.pickle'}
 
-    def _set_loaded_map_indicator(self, path=None, kind=None):
+    def _set_loaded_map_indicator(self, path=None):
         """Update the persistent status bar label for the loaded map source."""
         if not hasattr(self, 'loaded_map_label'):
             return
@@ -269,18 +269,11 @@ class MapAnalysisMainWindow(QMainWindow):
             self.loaded_map_label.setToolTip("No map loaded")
             return
 
-        path_text = str(path)
-        try:
-            path_obj = Path(path_text)
-            display_name = path_obj.name
-        except (TypeError, ValueError):
-            display_name = ""
-
-        if not display_name:
-            display_name = "unknown"
+        path_obj = Path(path)
+        display_name = path_obj.name or "unknown"
 
         self.loaded_map_label.setText(f"Map: {display_name}")
-        self.loaded_map_label.setToolTip(path_text)
+        self.loaded_map_label.setToolTip(str(path_obj))
 
     def _load_map_data_from_pickle(self, file_path):
         """Load map data from a saved pickle file, including legacy formats."""
@@ -1085,7 +1078,7 @@ class MapAnalysisMainWindow(QMainWindow):
                     perf_msg = ""
                 
                 self.statusBar().showMessage(f"Loaded {n_spectra:,} spectra{perf_msg}")
-                self._set_loaded_map_indicator(directory, 'directory')
+                self._set_loaded_map_indicator(directory)
                 logger.info(f"Loaded map data with {n_spectra:,} spectra")
 
                 try:
@@ -1171,7 +1164,7 @@ class MapAnalysisMainWindow(QMainWindow):
                 f"Loaded {len(self.map_data.spectra)} spectra from single file "
                 f"({self.map_data.width} × {self.map_data.height})"
             )
-            self._set_loaded_map_indicator(file_path, 'single_file')
+            self._set_loaded_map_indicator(file_path)
             logger.info(f"Loaded single-file map with {len(self.map_data.spectra)} spectra")
 
             try:
@@ -6989,7 +6982,7 @@ The map is now ready for analysis!"""
             QMessageBox.information(self, "Load Successful", summary_text)
             
             self.statusBar().showMessage(f"PKL map loaded: {spectra_count} spectra")
-            self._set_loaded_map_indicator(file_path, 'pkl')
+            self._set_loaded_map_indicator(file_path)
             
         except Exception as e:
             self.progress_status.hide_progress()
@@ -7551,6 +7544,7 @@ The map is now ready for analysis!"""
             
             spectra_count = len(self.map_data.spectra)
             self.statusBar().showMessage(f"PKL map loaded: {spectra_count:,} spectra")
+            self._set_loaded_map_indicator(file_path)
             
         except Exception as e:
             self.progress_status.hide_progress()

--- a/map_analysis_2d/ui/test_last_map_restore.py
+++ b/map_analysis_2d/ui/test_last_map_restore.py
@@ -18,9 +18,25 @@ class _DummyProgress:
 class _DummyStatusBar:
     def __init__(self):
         self.messages = []
+        self.permanent_widgets = []
 
     def showMessage(self, message, *_args):
         self.messages.append(message)
+
+    def addPermanentWidget(self, widget):
+        self.permanent_widgets.append(widget)
+
+
+class _DummyLabel:
+    def __init__(self, text=""):
+        self.text = text
+        self.tooltip = ""
+
+    def setText(self, text):
+        self.text = text
+
+    def setToolTip(self, tooltip):
+        self.tooltip = tooltip
 
 
 class LastMapRestoreTest(unittest.TestCase):
@@ -36,7 +52,32 @@ class LastMapRestoreTest(unittest.TestCase):
         window.on_tab_changed = MagicMock()
         status_bar = _DummyStatusBar()
         window.statusBar = lambda: status_bar
+        window.loaded_map_label = _DummyLabel("Map: none")
         return window
+
+    def test_loaded_map_indicator_shows_empty_state(self):
+        window = self._make_window()
+
+        window._set_loaded_map_indicator()
+
+        self.assertEqual(window.loaded_map_label.text, "Map: none")
+        self.assertEqual(window.loaded_map_label.tooltip, "No map loaded")
+
+    def test_loaded_map_indicator_shows_file_name_and_full_path_tooltip(self):
+        window = self._make_window()
+
+        window._set_loaded_map_indicator("/tmp/example.pkl", "pkl")
+
+        self.assertEqual(window.loaded_map_label.text, "Map: example.pkl")
+        self.assertEqual(window.loaded_map_label.tooltip, "/tmp/example.pkl")
+
+    def test_loaded_map_indicator_shows_directory_name_and_full_path_tooltip(self):
+        window = self._make_window()
+
+        window._set_loaded_map_indicator("/tmp/my_map_folder", "directory")
+
+        self.assertEqual(window.loaded_map_label.text, "Map: my_map_folder")
+        self.assertEqual(window.loaded_map_label.tooltip, "/tmp/my_map_folder")
 
     def test_restore_last_map_treats_legacy_single_file_pkl_as_pickle(self):
         window = self._make_window()
@@ -63,6 +104,8 @@ class LastMapRestoreTest(unittest.TestCase):
         single_file_loader.assert_not_called()
         self.assertIs(window.map_data, restored_map)
         cfg.set.assert_any_call("map_analysis.last_map_type", "pkl")
+        self.assertEqual(window.loaded_map_label.text, "Map: saved_map.pkl")
+        self.assertEqual(window.loaded_map_label.tooltip, str(pkl_path))
 
     def test_load_map_from_pkl_persists_pkl_type(self):
         window = self._make_window()
@@ -83,6 +126,8 @@ class LastMapRestoreTest(unittest.TestCase):
 
         cfg.set.assert_any_call("map_analysis.last_map_path", "/tmp/test-map.pkl")
         cfg.set.assert_any_call("map_analysis.last_map_type", "pkl")
+        self.assertEqual(window.loaded_map_label.text, "Map: test-map.pkl")
+        self.assertEqual(window.loaded_map_label.tooltip, "/tmp/test-map.pkl")
 
 
 if __name__ == "__main__":

--- a/map_analysis_2d/ui/test_last_map_restore.py
+++ b/map_analysis_2d/ui/test_last_map_restore.py
@@ -66,7 +66,7 @@ class LastMapRestoreTest(unittest.TestCase):
     def test_loaded_map_indicator_shows_file_name_and_full_path_tooltip(self):
         window = self._make_window()
 
-        window._set_loaded_map_indicator("/tmp/example.pkl", "pkl")
+        window._set_loaded_map_indicator("/tmp/example.pkl")
 
         self.assertEqual(window.loaded_map_label.text, "Map: example.pkl")
         self.assertEqual(window.loaded_map_label.tooltip, "/tmp/example.pkl")
@@ -74,7 +74,7 @@ class LastMapRestoreTest(unittest.TestCase):
     def test_loaded_map_indicator_shows_directory_name_and_full_path_tooltip(self):
         window = self._make_window()
 
-        window._set_loaded_map_indicator("/tmp/my_map_folder", "directory")
+        window._set_loaded_map_indicator("/tmp/my_map_folder")
 
         self.assertEqual(window.loaded_map_label.text, "Map: my_map_folder")
         self.assertEqual(window.loaded_map_label.tooltip, "/tmp/my_map_folder")
@@ -128,6 +128,22 @@ class LastMapRestoreTest(unittest.TestCase):
         cfg.set.assert_any_call("map_analysis.last_map_type", "pkl")
         self.assertEqual(window.loaded_map_label.text, "Map: test-map.pkl")
         self.assertEqual(window.loaded_map_label.tooltip, "/tmp/test-map.pkl")
+
+    def test_internal_pkl_loader_updates_loaded_map_indicator(self):
+        window = self._make_window()
+        window.cosmic_ray_manager = object()
+
+        restored_map = SimpleNamespace(
+            spectra={(0, 0): SimpleNamespace(wavenumbers=[100.0, 200.0], intensities=[1.0, 2.0], processed_intensities=None)},
+            target_wavenumbers=[100.0, 200.0],
+            wavenumbers=[100.0, 200.0],
+        )
+
+        with patch("pkl_utils.safe_pickle_load", return_value={"map_data": restored_map}):
+            window._load_pkl_file("/tmp/imported-map.pkl")
+
+        self.assertEqual(window.loaded_map_label.text, "Map: imported-map.pkl")
+        self.assertEqual(window.loaded_map_label.tooltip, "/tmp/imported-map.pkl")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## **User description**
## Summary
- Add a persistent status-bar label showing the currently loaded 2D map file or folder name.
- Show the full loaded path as the label tooltip.
- Cover empty, file, folder, restore, and PKL-load indicator behavior in the existing restore test module.

## Test Plan
- python3 -m py_compile map_analysis_2d/ui/main_window.py map_analysis_2d/ui/test_last_map_restore.py
- git diff --check -- map_analysis_2d/ui/main_window.py map_analysis_2d/ui/test_last_map_restore.py

## Note
- Full unittest execution was not run because PySide6 is not installed for the default python3 interpreter in this WSL environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a permanent status-bar “Map” indicator that shows the currently loaded 2D map file or folder. The tooltip shows the full path and updates on directory/single-file/PKL loads and on restore.

- **New Features**
  - Added a status-bar label with default state “Map: none” and tooltip “No map loaded”.
  - Updates the indicator when loading from a directory, a single file, PKL (public and internal loaders), and after restore.
  - Tests cover the empty state; file, folder, restore; and both PKL load paths.

<sup>Written for commit 0f12f32051deaedebc8173d8705dd0eb8784a0f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Show the loaded map name in the status bar**

### What Changed
- The status bar now keeps a visible label for the current map, showing `Map: none` when nothing is loaded.
- After loading a map from a folder, single file, or saved PKL, the label updates to the map or file name and its tooltip shows the full path.
- Restoring the last map now also refreshes this label so the shown source stays in sync.
- Tests now cover the empty state and the label updates for file, folder, restore, and PKL loads.

### Impact
`✅ Clearer map source at a glance`
`✅ Fewer confusing reloads after restore`
`✅ Safer map-loading behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
