### PR TITLE
Add copy buttons for Mean Area and Median Area

### DIFF
--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -243,7 +243,7 @@ class OverallStatsWidget(QWidget):
         self._copy_mean_button.setEnabled(np.isfinite(self._stats.mean_area))
         self._copy_median_button.setEnabled(np.isfinite(self._stats.median_area))
 
-    def _copy_stat_value(self, attr_name: str) -> None:
+    def _copy_stat_value(self, attr_name: str, *_) -> None:
         """Copy a named statistics value to the clipboard if finite."""
         if self._stats is None:
             return

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import Optional, Sequence
 
 from PySide6.QtCore import Slot
@@ -116,68 +117,66 @@ class OverallStatsWidget(QWidget):
         for label in (self.fitted_pixels_label, self.success_rate_label):
             self._main_layout.addWidget(label)
 
-        self._mean_area_row = QWidget()
-        self._mean_area_layout = QHBoxLayout(self._mean_area_row)
-        self._mean_area_layout.setContentsMargins(0, 0, 0, 0)
-        self._mean_area_layout.setSpacing(6)
-        self.mean_area_label = QLabel("Mean Area: --")
-        self.mean_area_label.setToolTip("Average total integrated area over successfully fitted pixels.")
-        self._copy_mean_button = QPushButton("Copy")
         icon = _style_icon(QStyle.StandardPixmap.SP_DialogSaveButton)
-        if icon is not None:
-            self._copy_mean_button.setIcon(icon)
-        self._copy_mean_button.setToolTip("Copy the mean area to the clipboard.")
-        self._copy_mean_button.setEnabled(False)
-        self._copy_mean_button.clicked.connect(self._copy_mean_area)
-        self._mean_area_layout.addWidget(self.mean_area_label)
-        self._mean_area_layout.addStretch(1)
-        self._mean_area_layout.addWidget(self._copy_mean_button)
-        self._main_layout.addWidget(self._mean_area_row)
 
-        self._median_area_row = QWidget()
-        self._median_area_layout = QHBoxLayout(self._median_area_row)
-        self._median_area_layout.setContentsMargins(0, 0, 0, 0)
-        self._median_area_layout.setSpacing(6)
-        self.median_area_label = QLabel("Median Area: --")
-        self.median_area_label.setToolTip("Median total integrated area over successfully fitted pixels.")
-        self._copy_median_button = QPushButton("Copy")
-        if icon is not None:
-            self._copy_median_button.setIcon(icon)
-        self._copy_median_button.setToolTip("Copy the median area to the clipboard.")
-        self._copy_median_button.setEnabled(False)
-        self._copy_median_button.clicked.connect(self._copy_median_area)
-        self._median_area_layout.addWidget(self.median_area_label)
-        self._median_area_layout.addStretch(1)
-        self._median_area_layout.addWidget(self._copy_median_button)
-        self._main_layout.addWidget(self._median_area_row)
+        self.mean_area_label, self._copy_mean_button = self._create_stat_row(
+            "Mean Area: --",
+            "Average total integrated area over successfully fitted pixels.",
+            "Copy the mean area to the clipboard.",
+            partial(self._copy_stat_value, "mean_area"),
+            icon,
+        )
+        self.median_area_label, self._copy_median_button = self._create_stat_row(
+            "Median Area: --",
+            "Median total integrated area over successfully fitted pixels.",
+            "Copy the median area to the clipboard.",
+            partial(self._copy_stat_value, "median_area"),
+            icon,
+        )
 
         self._rows_layout = QVBoxLayout()
         self._rows_layout.setSpacing(2)
         self._main_layout.addLayout(self._rows_layout)
 
-        self._grand_total_row = QWidget()
-        self._grand_total_layout = QHBoxLayout(self._grand_total_row)
-        self._grand_total_layout.setContentsMargins(0, 0, 0, 0)
-        self._grand_total_layout.setSpacing(6)
+        self.grand_total_label, self._copy_button = self._create_stat_row(
+            "",
+            "Sum of integrated intensity across all fitted peaks and pixels.",
+            "Copy the grand total area to the clipboard.",
+            partial(self._copy_stat_value, "grand_total_area"),
+            icon,
+        )
 
-        self.grand_total_label = QLabel()
-        self.grand_total_label.setToolTip("Sum of integrated intensity across all fitted peaks and pixels.")
-        self._copy_button = QPushButton("Copy")
-        icon = _style_icon(QStyle.StandardPixmap.SP_DialogSaveButton)
-        if icon is not None:
-            self._copy_button.setIcon(icon)
-        self._copy_button.setToolTip("Copy the grand total area to the clipboard.")
-        self._copy_button.setEnabled(False)
-        self._copy_button.clicked.connect(self._copy_grand_total)
-        self._grand_total_layout.addWidget(self.grand_total_label)
-        self._grand_total_layout.addStretch(1)
-        self._grand_total_layout.addWidget(self._copy_button)
-
-        self._main_layout.addWidget(self._grand_total_row)
         self.histogram_widget = MiniHistogramWidget()
         self.histogram_widget.hide()
         self._main_layout.addWidget(self.histogram_widget)
         self.clear_stats()
+
+    def _create_stat_row(
+        self,
+        label_text: str,
+        label_tooltip: str,
+        button_tooltip: str,
+        copy_slot,
+        icon,
+    ) -> tuple[QLabel, QPushButton]:
+        """Create a label + Copy button row and append it to the main layout."""
+        row = QWidget()
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        label = QLabel(label_text)
+        label.setToolTip(label_tooltip)
+        button = QPushButton("Copy")
+        if icon is not None:
+            button.setIcon(icon)
+        button.setToolTip(button_tooltip)
+        button.setEnabled(False)
+        button.clicked.connect(copy_slot)
+        layout.addWidget(label)
+        layout.addStretch(1)
+        layout.addWidget(button)
+        self._main_layout.addWidget(row)
+        return label, button
 
     def _clear_rows(self) -> None:
         while self._rows_layout.count():
@@ -240,27 +239,17 @@ class OverallStatsWidget(QWidget):
         self.median_area_label.setText(f"Median Area: {self._format_number(self._stats.median_area)}")
         self.grand_total_label.setText(f"Grand total area: {self._format_number(self._stats.grand_total_area)}")
         self.histogram_widget.set_values(self._stats.total_areas)
-        self._copy_button.setEnabled(True)
-        self._copy_mean_button.setEnabled(True)
-        self._copy_median_button.setEnabled(True)
+        self._copy_button.setEnabled(np.isfinite(self._stats.grand_total_area))
+        self._copy_mean_button.setEnabled(np.isfinite(self._stats.mean_area))
+        self._copy_median_button.setEnabled(np.isfinite(self._stats.median_area))
 
-    def _copy_grand_total(self):
+    def _copy_stat_value(self, attr_name: str) -> None:
+        """Copy a named statistics value to the clipboard if finite."""
         if self._stats is None:
             return
-        clipboard = QGuiApplication.clipboard()
-        clipboard.setText(f"{self._stats.grand_total_area:.2f}")
-
-    def _copy_mean_area(self):
-        if self._stats is None:
-            return
-        clipboard = QGuiApplication.clipboard()
-        clipboard.setText(f"{self._stats.mean_area:.2f}")
-
-    def _copy_median_area(self):
-        if self._stats is None:
-            return
-        clipboard = QGuiApplication.clipboard()
-        clipboard.setText(f"{self._stats.median_area:.2f}")
+        value = getattr(self._stats, attr_name, None)
+        if value is not None and np.isfinite(value):
+            QGuiApplication.clipboard().setText(f"{value:.2f}")
 
     def _format_number(self, value: float) -> str:
         if not np.isfinite(value):

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -113,18 +113,43 @@ class OverallStatsWidget(QWidget):
         self.fitted_pixels_label.setToolTip("Pixels with all required fitted peak parameters.")
         self.success_rate_label = QLabel("Success Rate: --")
         self.success_rate_label.setToolTip("Percentage of map pixels with complete successful fits.")
+        for label in (self.fitted_pixels_label, self.success_rate_label):
+            self._main_layout.addWidget(label)
+
+        self._mean_area_row = QWidget()
+        self._mean_area_layout = QHBoxLayout(self._mean_area_row)
+        self._mean_area_layout.setContentsMargins(0, 0, 0, 0)
+        self._mean_area_layout.setSpacing(6)
         self.mean_area_label = QLabel("Mean Area: --")
         self.mean_area_label.setToolTip("Average total integrated area over successfully fitted pixels.")
+        self._copy_mean_button = QPushButton("Copy")
+        icon = _style_icon(QStyle.StandardPixmap.SP_DialogSaveButton)
+        if icon is not None:
+            self._copy_mean_button.setIcon(icon)
+        self._copy_mean_button.setToolTip("Copy the mean area to the clipboard.")
+        self._copy_mean_button.setEnabled(False)
+        self._copy_mean_button.clicked.connect(self._copy_mean_area)
+        self._mean_area_layout.addWidget(self.mean_area_label)
+        self._mean_area_layout.addStretch(1)
+        self._mean_area_layout.addWidget(self._copy_mean_button)
+        self._main_layout.addWidget(self._mean_area_row)
+
+        self._median_area_row = QWidget()
+        self._median_area_layout = QHBoxLayout(self._median_area_row)
+        self._median_area_layout.setContentsMargins(0, 0, 0, 0)
+        self._median_area_layout.setSpacing(6)
         self.median_area_label = QLabel("Median Area: --")
         self.median_area_label.setToolTip("Median total integrated area over successfully fitted pixels.")
-
-        for label in (
-            self.fitted_pixels_label,
-            self.success_rate_label,
-            self.mean_area_label,
-            self.median_area_label,
-        ):
-            self._main_layout.addWidget(label)
+        self._copy_median_button = QPushButton("Copy")
+        if icon is not None:
+            self._copy_median_button.setIcon(icon)
+        self._copy_median_button.setToolTip("Copy the median area to the clipboard.")
+        self._copy_median_button.setEnabled(False)
+        self._copy_median_button.clicked.connect(self._copy_median_area)
+        self._median_area_layout.addWidget(self.median_area_label)
+        self._median_area_layout.addStretch(1)
+        self._median_area_layout.addWidget(self._copy_median_button)
+        self._main_layout.addWidget(self._median_area_row)
 
         self._rows_layout = QVBoxLayout()
         self._rows_layout.setSpacing(2)
@@ -173,6 +198,8 @@ class OverallStatsWidget(QWidget):
         self.median_area_label.setText("Median Area: --")
         self.histogram_widget.set_values([])
         self._copy_button.setEnabled(False)
+        self._copy_mean_button.setEnabled(False)
+        self._copy_median_button.setEnabled(False)
 
     def set_loading(self, loading: bool, message: str = "Computing statistics..."):
         self.loading_label.setText(message)
@@ -214,12 +241,26 @@ class OverallStatsWidget(QWidget):
         self.grand_total_label.setText(f"Grand total area: {self._format_number(self._stats.grand_total_area)}")
         self.histogram_widget.set_values(self._stats.total_areas)
         self._copy_button.setEnabled(True)
+        self._copy_mean_button.setEnabled(True)
+        self._copy_median_button.setEnabled(True)
 
     def _copy_grand_total(self):
         if self._stats is None:
             return
         clipboard = QGuiApplication.clipboard()
         clipboard.setText(f"{self._stats.grand_total_area:.2f}")
+
+    def _copy_mean_area(self):
+        if self._stats is None:
+            return
+        clipboard = QGuiApplication.clipboard()
+        clipboard.setText(f"{self._stats.mean_area:.2f}")
+
+    def _copy_median_area(self):
+        if self._stats is None:
+            return
+        clipboard = QGuiApplication.clipboard()
+        clipboard.setText(f"{self._stats.median_area:.2f}")
 
     def _format_number(self, value: float) -> str:
         if not np.isfinite(value):


### PR DESCRIPTION
## **User description**
Add Copy buttons next to Mean Area and Median Area rows in the Overall Statistics panel, matching the existing Grand Total pattern. Each button copies the raw value (no plus/minus std) as a plain decimal to the clipboard. Buttons are disabled until fitting results are available and reset on clear.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copy buttons for Mean Area and Median Area in the Overall Statistics panel and aligns Grand Total with the same pattern. Each button copies the raw value (two decimals), only enables when the value is finite, and resets on clear.

- **New Features**
  - "Copy" buttons for Mean Area and Median Area; copy plain decimal (two decimals), no ± spread.

- **Refactors**
  - Extracted `_create_stat_row()` and unified `_copy_stat_value(attr_name)` via `functools.partial`; guarded buttons with `np.isfinite()` and applied minor review auto-fixes.

<sup>Written for commit cca0477107f93e58b07adc3e3968ec9cbf872ba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add copy buttons for Mean Area and Median Area**

### What Changed
- Added Copy buttons for the Mean Area and Median Area rows in the Overall Statistics panel
- Each button copies the raw value to the clipboard as a plain decimal, without the displayed plus/minus spread
- The new buttons stay disabled until statistics are available and reset when results are cleared

### Impact
`✅ Faster copying of summary values`
`✅ Fewer mistakes when sharing area statistics`
`✅ Clearer access to mean and median results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
