### PR TITLE
Add SNR-based phase detection statistics to Overall Statistics panel

### DIFF
--- a/map_analysis_2d/core/statistics.py
+++ b/map_analysis_2d/core/statistics.py
@@ -24,6 +24,7 @@ class OverallStatistics:
     median_area: float
     std_area: float
     total_areas: List[float]
+    snr_values: List[float]  # per successfully-fitted pixel, parallel to total_areas
 
 
 def _iter_positions(*param_maps: Mapping[PosKey, float]) -> Iterable[PosKey]:
@@ -52,6 +53,7 @@ def compute_overall_statistics(fitting_results: dict) -> Optional[OverallStatist
 
     map_params: Dict[str, Dict[PosKey, float]] = fitting_results.get("map_parameters") or {}
     fit_errors: Mapping[PosKey, str] = fitting_results.get("fit_errors") or {}
+    snr_map: Mapping[PosKey, float] = fitting_results.get("snr") or {}
 
     peak_amp_dicts = [map_params.get(f"P{i}_Amp", {}) for i in range(1, len(shapes) + 1)]
     peak_wid_dicts = [map_params.get(f"P{i}_Wid", {}) for i in range(1, len(shapes) + 1)]
@@ -65,6 +67,7 @@ def compute_overall_statistics(fitting_results: dict) -> Optional[OverallStatist
     per_peak_totals = np.zeros(len(shapes), dtype=float)
     grand_total = 0.0
     total_areas: List[float] = []
+    snr_values: List[float] = []
     any_valid = False
 
     for pos_key in sorted(positions, key=lambda pos: (pos[1], pos[0])):
@@ -91,6 +94,7 @@ def compute_overall_statistics(fitting_results: dict) -> Optional[OverallStatist
         total_area = float(sum(per_pos_values))
         total_areas.append(total_area)
         grand_total += total_area
+        snr_values.append(float(snr_map.get(pos_key, 0.0)))
 
     fitted_count = len(total_areas)
     total_count = len(positions)
@@ -114,4 +118,5 @@ def compute_overall_statistics(fitting_results: dict) -> Optional[OverallStatist
         median_area=median_area,
         std_area=std_area,
         total_areas=total_areas,
+        snr_values=snr_values,
     )

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -10,6 +10,7 @@ from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
+    QDoubleSpinBox,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -117,6 +118,34 @@ class OverallStatsWidget(QWidget):
         for label in (self.fitted_pixels_label, self.success_rate_label):
             self._main_layout.addWidget(label)
 
+        snr_row = QHBoxLayout()
+        snr_row.setContentsMargins(0, 0, 0, 0)
+        snr_row.setSpacing(4)
+        snr_row.addWidget(QLabel("SNR threshold:"))
+        self.snr_threshold_spin = QDoubleSpinBox()
+        self.snr_threshold_spin.setRange(0.1, 100.0)
+        self.snr_threshold_spin.setSingleStep(0.5)
+        self.snr_threshold_spin.setValue(3.0)
+        self.snr_threshold_spin.setSuffix(" SNR")
+        self.snr_threshold_spin.setToolTip(
+            "Pixels with fitted peak SNR at or above this value are counted as signal-rich."
+        )
+        self.snr_threshold_spin.valueChanged.connect(self._render_stats)
+        snr_row.addWidget(self.snr_threshold_spin)
+        snr_row.addStretch(1)
+        self._main_layout.addLayout(snr_row)
+
+        self.meaningful_pixels_label = QLabel("Detected (SNR ≥ 3.0): --")
+        self.meaningful_pixels_label.setToolTip(
+            "Pixels whose fitted peak SNR meets or exceeds the threshold — phase is detectable at this spot."
+        )
+        self.no_signal_label = QLabel("Not detected: --")
+        self.no_signal_label.setToolTip(
+            "Pixels below the SNR threshold or that failed to fit — no detectable phase signal at this spot."
+        )
+        for label in (self.meaningful_pixels_label, self.no_signal_label):
+            self._main_layout.addWidget(label)
+
         icon = _style_icon(QStyle.StandardPixmap.SP_DialogSaveButton)
 
         self.mean_area_label, self._copy_mean_button = self._create_stat_row(
@@ -193,6 +222,9 @@ class OverallStatsWidget(QWidget):
         self.fitted_pixels_label.setText("Fitted Pixels: --")
         self.success_rate_label.setText("Success Rate: --")
         self.success_rate_label.setStyleSheet("color: #777;")
+        self.meaningful_pixels_label.setText("Detected (SNR ≥ 3.0): --")
+        self.meaningful_pixels_label.setStyleSheet("color: #777;")
+        self.no_signal_label.setText("Not detected: --")
         self.mean_area_label.setText("Mean Area: --")
         self.median_area_label.setText("Median Area: --")
         self.histogram_widget.set_values([])
@@ -233,6 +265,23 @@ class OverallStatsWidget(QWidget):
         self.success_rate_label.setStyleSheet(
             f"color: {self._quality_color(self._stats.success_rate)}; font-weight: bold;"
         )
+
+        threshold = self.snr_threshold_spin.value()
+        meaningful = sum(1 for v in self._stats.snr_values if v >= threshold)
+        no_signal = self._stats.total_count - meaningful
+        total = self._stats.total_count
+        meaningful_pct = (meaningful / total * 100.0) if total else 0.0
+        no_signal_pct = (no_signal / total * 100.0) if total else 0.0
+        self.meaningful_pixels_label.setText(
+            f"Detected (SNR ≥ {threshold:.1f}): {meaningful:,} / {total:,}  ({meaningful_pct:.1f}%)"
+        )
+        self.meaningful_pixels_label.setStyleSheet(
+            f"color: {self._quality_color(meaningful_pct)}; font-weight: bold;"
+        )
+        self.no_signal_label.setText(
+            f"Not detected: {no_signal:,} / {total:,}  ({no_signal_pct:.1f}%)"
+        )
+
         self.mean_area_label.setText(
             f"Mean Area: {self._format_number(self._stats.mean_area)} +/- {self._format_number(self._stats.std_area)}"
         )

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -135,7 +135,7 @@ class OverallStatsWidget(QWidget):
         snr_row.addStretch(1)
         self._main_layout.addLayout(snr_row)
 
-        self.meaningful_pixels_label = QLabel("Detected (SNR ≥ 3.0): --")
+        self.meaningful_pixels_label = QLabel(f"Detected (SNR ≥ {self.snr_threshold_spin.value():.1f}): --")
         self.meaningful_pixels_label.setToolTip(
             "Pixels whose fitted peak SNR meets or exceeds the threshold — phase is detectable at this spot."
         )
@@ -222,7 +222,7 @@ class OverallStatsWidget(QWidget):
         self.fitted_pixels_label.setText("Fitted Pixels: --")
         self.success_rate_label.setText("Success Rate: --")
         self.success_rate_label.setStyleSheet("color: #777;")
-        self.meaningful_pixels_label.setText("Detected (SNR ≥ 3.0): --")
+        self.meaningful_pixels_label.setText(f"Detected (SNR ≥ {self.snr_threshold_spin.value():.1f}): --")
         self.meaningful_pixels_label.setStyleSheet("color: #777;")
         self.no_signal_label.setText("Not detected: --")
         self.mean_area_label.setText("Mean Area: --")

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -245,6 +245,7 @@ class OverallStatsWidget(QWidget):
             return
 
         self._stats = stats
+        self.set_loading(False)
         self._render_stats()
 
     def _render_stats(self):

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -289,9 +289,9 @@ class OverallStatsWidget(QWidget):
         self.median_area_label.setText(f"Median Area: {self._format_number(self._stats.median_area)}")
         self.grand_total_label.setText(f"Grand total area: {self._format_number(self._stats.grand_total_area)}")
         self.histogram_widget.set_values(self._stats.total_areas)
-        self._copy_button.setEnabled(np.isfinite(self._stats.grand_total_area))
-        self._copy_mean_button.setEnabled(np.isfinite(self._stats.mean_area))
-        self._copy_median_button.setEnabled(np.isfinite(self._stats.median_area))
+        self._copy_button.setEnabled(bool(np.isfinite(self._stats.grand_total_area)))
+        self._copy_mean_button.setEnabled(bool(np.isfinite(self._stats.mean_area)))
+        self._copy_median_button.setEnabled(bool(np.isfinite(self._stats.median_area)))
 
     def _copy_stat_value(self, attr_name: str, *_) -> None:
         """Copy a named statistics value to the clipboard if finite."""

--- a/map_analysis_2d/workers/peak_fitting_worker.py
+++ b/map_analysis_2d/workers/peak_fitting_worker.py
@@ -62,6 +62,7 @@ class PeakFittingWorker(QThread):
                 'param_names': param_names,
                 'map_parameters': {name: {} for name in param_names},
                 'r_squared': {},
+                'snr': {},
                 'fit_errors': {},
                 'fit_warnings': {},
                 'config': dict(self.config),
@@ -126,6 +127,15 @@ class PeakFittingWorker(QThread):
                         ss_res = np.sum((y_fit - model_func(x_fit, *popt)) ** 2)
                         ss_tot = np.sum((y_fit - np.mean(y_fit)) ** 2)
                         r_squared = 1 - (ss_res / ss_tot) if ss_tot > 0 else 0.0
+
+                        n_pts = len(y_fit)
+                        rmse = np.sqrt(ss_res / n_pts) if n_pts > 0 else 0.0
+                        amp_indices = [i for i, name in enumerate(param_names) if name.endswith('_Amp')]
+                        if amp_indices and rmse > 0:
+                            max_amp = max(float(popt[i]) for i in amp_indices)
+                            results['snr'][pos_key] = max_amp / rmse
+                        else:
+                            results['snr'][pos_key] = 0.0
 
                         for param_index, name in enumerate(param_names):
                             results['map_parameters'][name][pos_key] = popt[param_index]

--- a/map_analysis_2d/workers/peak_fitting_worker.py
+++ b/map_analysis_2d/workers/peak_fitting_worker.py
@@ -55,6 +55,7 @@ class PeakFittingWorker(QThread):
             bounds = self.config['bounds']
             min_wn, max_wn = self.config['region']
 
+            amp_indices = [i for i, name in enumerate(param_names) if name.endswith('_Amp')]
             total = len(self.spectra)
             results = {
                 'n_peaks': len(self.config['shapes']),
@@ -130,10 +131,9 @@ class PeakFittingWorker(QThread):
 
                         n_pts = len(y_fit)
                         rmse = np.sqrt(ss_res / n_pts) if n_pts > 0 else 0.0
-                        amp_indices = [i for i, name in enumerate(param_names) if name.endswith('_Amp')]
-                        if amp_indices and rmse > 0:
+                        if amp_indices:
                             max_amp = max(float(popt[i]) for i in amp_indices)
-                            results['snr'][pos_key] = max_amp / rmse
+                            results['snr'][pos_key] = max_amp / rmse if rmse > 0 else (np.inf if max_amp > 0 else 0.0)
                         else:
                             results['snr'][pos_key] = 0.0
 


### PR DESCRIPTION
## **User description**
## Summary

- **Per-pixel SNR** is now computed in the fitting worker: `SNR = max_peak_amplitude / RMSE_of_residuals`. This measures whether the fitted peak stands above the noise floor in the active spectral region.
- `OverallStatistics` carries a new `snr_values` list (one entry per successfully fitted pixel, parallel to `total_areas`).
- The **Overall Statistics** panel gains two new lines and a threshold control:
  - **SNR threshold spinbox** (0.1–100, default 3.0 SNR) — adjustable live without re-fitting.
  - **Detected (SNR ≥ N): X / total (Y%)** — color-coded green/orange/red by the same quality thresholds used for Success Rate.
  - **Not detected: X / total (Y%)** — pixels below threshold or that failed to fit entirely.

## Motivation

Users need to know what fraction of map spots contain a detectable Raman phase signal (e.g. Si) versus spots dominated by noise or background. The existing "Fitted Pixels" stat only tracks convergence, not spectral quality. The new stat answers "how many pixels actually showed the phase?" directly, expressed as a count and percentage.

## Reviewer notes

- SNR is only stored for *successfully fitted* pixels; failed-fit pixels are counted as "not detected" automatically (their position is absent from `results['snr']`).
- The threshold spinbox triggers `_render_stats()` on change — counts recompute from the cached `snr_values` list, no re-fitting required.
- Three files changed: `workers/peak_fitting_worker.py`, `core/statistics.py`, `ui/overall_stats_widget.py`.

## Test plan

- [ ] Run map peak fitting on a real dataset; verify "Detected" + "Not detected" counts sum to total pixel count.
- [ ] Adjust the SNR threshold spinbox — confirm counts update instantly.
- [ ] Clear fitting results — confirm both labels reset to `--`.
- [ ] Run on a noisy dataset — confirm "Detected" percentage is lower than for a clean dataset.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SNR-based phase detection to Overall Statistics so users can see how many pixels have a detectable signal at an adjustable threshold. Also fixes a stuck loading state and a Copy-buttons disabled bug after fitting.

- New Features
  - Compute per-pixel SNR in the fitting worker: SNR = max peak amplitude / RMSE of residuals; stored in `results['snr']`.
  - `OverallStatistics` now includes `snr_values` aligned with `total_areas`.
  - Overall Statistics panel adds an SNR threshold control (0.1–100, default 3.0) and shows “Detected (SNR ≥ N)” and “Not detected” counts and percentages; failed fits count as not detected.

- Bug Fixes
  - Handle RMSE = 0: SNR is `inf` when peak amplitude > 0, preventing false “Not detected”.
  - Move amplitude-index lookup outside the per-spectrum loop to reduce worker overhead.
  - Use the current spin value for initial and cleared labels to keep text in sync.
  - Clear loading state in `update_from_fitting_results` so the progress bar doesn’t persist.
  - Fix Copy buttons staying disabled by wrapping `np.isfinite(...)` in `bool()` for `setEnabled()`.

<sup>Written for commit 2523b39d30600b2cf99b67cb5f038391d95e19d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Show phase-detection counts based on peak SNR**

### What Changed
- The Overall Statistics panel now shows how many fitted pixels have a detectable signal above a configurable SNR threshold, along with how many do not.
- The SNR threshold can be changed live, and the detected/not detected counts update immediately without rerunning the fit.
- Clean and failed fits are both counted in the “Not detected” total, so the two counts add up to the full map size.
- The panel resets the new SNR-based lines when statistics are cleared.

### Impact
`✅ Clearer phase-detection results`
`✅ Live threshold checks without refitting`
`✅ Counts that match the full map size`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
