### PR TITLE
Fix stale peak fitting results invalidation

### DIFF
--- a/map_analysis_2d/core/peak_fitting_state.py
+++ b/map_analysis_2d/core/peak_fitting_state.py
@@ -7,6 +7,19 @@ def invalidate_peak_fitting_results(owner, control_panel=None):
     """Clear stale fit results and disable export until a new run completes."""
     owner.peak_fitting_results = None
 
+    plot_widget = getattr(owner, "peak_fitting_plot_widget", None)
+    if plot_widget is not None:
+        map_widget = getattr(plot_widget, "map_widget", None)
+        if map_widget is not None and hasattr(map_widget, "clear_plot"):
+            map_widget.clear_plot()
+
+        spectrum_widget = getattr(plot_widget, "spectrum_widget", None)
+        if spectrum_widget is not None and hasattr(spectrum_widget, "clear_plot"):
+            spectrum_widget.clear_plot()
+
+        if hasattr(plot_widget, "show_spectrum_panel"):
+            plot_widget.show_spectrum_panel(False)
+
     if control_panel is not None and hasattr(control_panel, "results_panel"):
         control_panel.results_panel.clear()
 

--- a/map_analysis_2d/core/statistics.py
+++ b/map_analysis_2d/core/statistics.py
@@ -19,6 +19,7 @@ class OverallStatistics:
     grand_total_area: float
     fitted_count: int
     total_count: int
+    failed_count: int
     success_rate: float
     mean_area: float
     median_area: float
@@ -98,6 +99,7 @@ def compute_overall_statistics(fitting_results: dict) -> Optional[OverallStatist
 
     fitted_count = len(total_areas)
     total_count = len(positions)
+    failed_count = total_count - fitted_count
     success_rate = (fitted_count / total_count) * 100.0 if total_count else 0.0
     if any_valid:
         mean_area = float(np.mean(total_areas))
@@ -113,6 +115,7 @@ def compute_overall_statistics(fitting_results: dict) -> Optional[OverallStatist
         grand_total_area=float(grand_total),
         fitted_count=fitted_count,
         total_count=total_count,
+        failed_count=failed_count,
         success_rate=success_rate,
         mean_area=mean_area,
         median_area=median_area,

--- a/map_analysis_2d/test_peak_fitting_review_fixes.py
+++ b/map_analysis_2d/test_peak_fitting_review_fixes.py
@@ -31,9 +31,28 @@ class DummyControlPanel:
         self.export_results_csv_btn = DummyButton()
 
 
+class DummyPlot:
+    def __init__(self):
+        self.cleared = False
+
+    def clear_plot(self):
+        self.cleared = True
+
+
+class DummyPeakFittingPlotWidget:
+    def __init__(self):
+        self.map_widget = DummyPlot()
+        self.spectrum_widget = DummyPlot()
+        self.spectrum_panel_visible = True
+
+    def show_spectrum_panel(self, visible):
+        self.spectrum_panel_visible = visible
+
+
 class DummyWindow:
     def __init__(self):
         self.peak_fitting_results = {"old": "results"}
+        self.peak_fitting_plot_widget = DummyPeakFittingPlotWidget()
 
 
 class PeakFittingReviewFixTests(unittest.TestCase):
@@ -50,6 +69,19 @@ class PeakFittingReviewFixTests(unittest.TestCase):
         self.assertIsNone(window.peak_fitting_results)
         self.assertFalse(control_panel.export_batch_btn.enabled)
         self.assertFalse(control_panel.export_results_csv_btn.enabled)
+
+    def test_invalidating_results_clears_stale_peak_fitting_plots(self):
+        state_module = load_module(
+            ROOT / "map_analysis_2d" / "core" / "peak_fitting_state.py",
+            "peak_fitting_state_under_test",
+        )
+        window = DummyWindow()
+
+        state_module.invalidate_peak_fitting_results(window)
+
+        self.assertTrue(window.peak_fitting_plot_widget.map_widget.cleared)
+        self.assertTrue(window.peak_fitting_plot_widget.spectrum_widget.cleared)
+        self.assertFalse(window.peak_fitting_plot_widget.spectrum_panel_visible)
 
     def test_merging_config_preserves_existing_visualization_selection(self):
         state_module = load_module(

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -1544,6 +1544,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         
     def setup_controls(self):
         """Setup controls for map peak fitting."""
+        self._suppress_fitting_config_changed = False
         
         # Region Selection
         region_group = QGroupBox("Fitting Region")
@@ -1561,8 +1562,8 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.max_wavenumber_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.max_wavenumber_spin.setMinimumWidth(50)
         
-        self.min_wavenumber_spin.valueChanged.connect(lambda _: self.fitting_config_changed.emit())
-        self.max_wavenumber_spin.valueChanged.connect(lambda _: self.fitting_config_changed.emit())
+        self.min_wavenumber_spin.valueChanged.connect(self._emit_fitting_config_changed)
+        self.max_wavenumber_spin.valueChanged.connect(self._emit_fitting_config_changed)
 
         region_layout.addWidget(QLabel("Min Wavenumber (cm⁻¹):"))
         region_layout.addWidget(self.min_wavenumber_spin)
@@ -1582,7 +1583,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.num_peaks_spin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.num_peaks_spin.setMinimumWidth(50)
         self.num_peaks_spin.valueChanged.connect(self._rebuild_peaks_ui)
-        self.num_peaks_spin.valueChanged.connect(lambda _: self.fitting_config_changed.emit())
+        self.num_peaks_spin.valueChanged.connect(self._emit_fitting_config_changed)
         num_peaks_layout.addWidget(self.num_peaks_spin)
         peaks_layout.addLayout(num_peaks_layout)
         
@@ -1650,6 +1651,15 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         self.eta_labels = []
         
         self._rebuild_peaks_ui()
+
+    def _emit_fitting_config_changed(self, *_):
+        if not getattr(self, "_suppress_fitting_config_changed", False):
+            self.fitting_config_changed.emit()
+
+    def _connect_peak_param_signals(self, *param_groups):
+        for param_group in param_groups:
+            for spin in param_group.values():
+                spin.valueChanged.connect(self._emit_fitting_config_changed)
 
     @staticmethod
     def _create_param_row(
@@ -1745,6 +1755,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
             eta_spins, eta_label = self._create_param_row(grid, "Eta (G/L):", 4, 0.5, 0.0, 1.0, step=0.1, range_max=1.0)
             self.eta_spins.append(eta_spins)
             self.eta_labels.append(eta_label)
+            self._connect_peak_param_signals(amp_spins, cen_spins, wid_spins, eta_spins)
             
             # Initially hide eta if not Pseudo-Voigt
             is_pv = shape_combo.currentText() == "Pseudo-Voigt"
@@ -1769,6 +1780,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         for spin in self.eta_spins[idx].values():
             spin.setVisible(is_pv)
         self._update_visualization_combo()
+        self._emit_fitting_config_changed()
         
     def _update_visualization_combo(self):
         current_key = self.visualization_combo.currentData()
@@ -1833,6 +1845,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         """Restore a previously used peak fitting configuration."""
         region = config.get("region")
         saved_visualize_key = config.get("visualize_key")
+        self._suppress_fitting_config_changed = True
 
         # Block signals to avoid spurious fitting_config_changed during restore.
         for spin in (self.min_wavenumber_spin, self.max_wavenumber_spin, self.num_peaks_spin):
@@ -1844,6 +1857,7 @@ class MapPeakFittingControlPanel(BaseControlPanel):
 
             shapes = config.get("shapes", [])
             if not shapes:
+                self._suppress_fitting_config_changed = False
                 return
 
             self.num_peaks_spin.setValue(len(shapes))
@@ -1858,9 +1872,11 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         expected_param_count = sum(4 if shape == "Pseudo-Voigt" else 3 for shape in shapes)
         if len(initial_params) < expected_param_count:
             logger.warning("Skipping peak fitting config restore: initial parameters are incomplete")
+            self._suppress_fitting_config_changed = False
             return
         if len(lower_bounds) < expected_param_count or len(upper_bounds) < expected_param_count:
             logger.warning("Skipping peak fitting config restore: parameter bounds are incomplete")
+            self._suppress_fitting_config_changed = False
             return
 
         # Signals were blocked while setting num_peaks, so the UI didn't rebuild
@@ -1898,4 +1914,5 @@ class MapPeakFittingControlPanel(BaseControlPanel):
                 self.visualization_combo.blockSignals(True)
                 self.visualization_combo.setCurrentIndex(selected_index)
                 self.visualization_combo.blockSignals(False)
+        self._suppress_fitting_config_changed = False
         self.visualization_parameter_changed.emit(self.visualization_combo.currentText())

--- a/map_analysis_2d/ui/control_panels.py
+++ b/map_analysis_2d/ui/control_panels.py
@@ -1846,73 +1846,71 @@ class MapPeakFittingControlPanel(BaseControlPanel):
         region = config.get("region")
         saved_visualize_key = config.get("visualize_key")
         self._suppress_fitting_config_changed = True
-
-        # Block signals to avoid spurious fitting_config_changed during restore.
-        for spin in (self.min_wavenumber_spin, self.max_wavenumber_spin, self.num_peaks_spin):
-            spin.blockSignals(True)
         try:
-            if region is not None:
-                self.min_wavenumber_spin.setValue(region[0])
-                self.max_wavenumber_spin.setValue(region[1])
+            # Block signals to avoid spurious fitting_config_changed during restore.
+            for spin in (self.min_wavenumber_spin, self.max_wavenumber_spin, self.num_peaks_spin):
+                spin.blockSignals(True)
+            try:
+                if region is not None:
+                    self.min_wavenumber_spin.setValue(region[0])
+                    self.max_wavenumber_spin.setValue(region[1])
 
-            shapes = config.get("shapes", [])
-            if not shapes:
-                self._suppress_fitting_config_changed = False
+                shapes = config.get("shapes", [])
+                if not shapes:
+                    return
+
+                self.num_peaks_spin.setValue(len(shapes))
+            finally:
+                for spin in (self.min_wavenumber_spin, self.max_wavenumber_spin, self.num_peaks_spin):
+                    spin.blockSignals(False)
+
+            # Validate before rebuilding: a rebuild resets all peaks to defaults, so
+            # bailing out after that would leave the panel in a partially-restored state.
+            initial_params = config.get("initial_params", [])
+            lower_bounds, upper_bounds = config.get("bounds", ([], []))
+            expected_param_count = sum(4 if shape == "Pseudo-Voigt" else 3 for shape in shapes)
+            if len(initial_params) < expected_param_count:
+                logger.warning("Skipping peak fitting config restore: initial parameters are incomplete")
+                return
+            if len(lower_bounds) < expected_param_count or len(upper_bounds) < expected_param_count:
+                logger.warning("Skipping peak fitting config restore: parameter bounds are incomplete")
                 return
 
-            self.num_peaks_spin.setValue(len(shapes))
+            # Signals were blocked while setting num_peaks, so the UI didn't rebuild
+            # automatically. Rebuild now so shape_combos / amp_spins etc. match shapes.
+            if len(self.shape_combos) != len(shapes):
+                self._rebuild_peaks_ui()
+
+            param_index = 0
+
+            for peak_index, shape in enumerate(shapes):
+                self.shape_combos[peak_index].setCurrentText(shape)
+
+                for param_group in (self.amp_spins[peak_index], self.cen_spins[peak_index], self.wid_spins[peak_index]):
+                    param_group['init'].setValue(initial_params[param_index])
+                    param_group['min'].setValue(lower_bounds[param_index])
+                    param_group['max'].setValue(upper_bounds[param_index])
+                    param_index += 1
+
+                if shape == "Pseudo-Voigt":
+                    self.eta_spins[peak_index]['init'].setValue(initial_params[param_index])
+                    self.eta_spins[peak_index]['min'].setValue(lower_bounds[param_index])
+                    self.eta_spins[peak_index]['max'].setValue(upper_bounds[param_index])
+                    param_index += 1
+
+            self._update_visualization_combo()
+
+            # Restore the saved visualization key, but treat "R-Squared" as the legacy
+            # default — if it was saved only because it used to be index 0, prefer the
+            # new default "Total_Area" instead.
+            restore_key = saved_visualize_key if saved_visualize_key != "R-Squared" else None
+            if restore_key is not None:
+                selected_index = self.visualization_combo.findData(restore_key)
+                if selected_index >= 0:
+                    # Block signals during restore to avoid a double render; emit once after.
+                    self.visualization_combo.blockSignals(True)
+                    self.visualization_combo.setCurrentIndex(selected_index)
+                    self.visualization_combo.blockSignals(False)
         finally:
-            for spin in (self.min_wavenumber_spin, self.max_wavenumber_spin, self.num_peaks_spin):
-                spin.blockSignals(False)
-
-        # Validate before rebuilding: a rebuild resets all peaks to defaults, so
-        # bailing out after that would leave the panel in a partially-restored state.
-        initial_params = config.get("initial_params", [])
-        lower_bounds, upper_bounds = config.get("bounds", ([], []))
-        expected_param_count = sum(4 if shape == "Pseudo-Voigt" else 3 for shape in shapes)
-        if len(initial_params) < expected_param_count:
-            logger.warning("Skipping peak fitting config restore: initial parameters are incomplete")
             self._suppress_fitting_config_changed = False
-            return
-        if len(lower_bounds) < expected_param_count or len(upper_bounds) < expected_param_count:
-            logger.warning("Skipping peak fitting config restore: parameter bounds are incomplete")
-            self._suppress_fitting_config_changed = False
-            return
-
-        # Signals were blocked while setting num_peaks, so the UI didn't rebuild
-        # automatically. Rebuild now so shape_combos / amp_spins etc. match shapes.
-        if len(self.shape_combos) != len(shapes):
-            self._rebuild_peaks_ui()
-
-        param_index = 0
-
-        for peak_index, shape in enumerate(shapes):
-            self.shape_combos[peak_index].setCurrentText(shape)
-
-            for param_group in (self.amp_spins[peak_index], self.cen_spins[peak_index], self.wid_spins[peak_index]):
-                param_group['init'].setValue(initial_params[param_index])
-                param_group['min'].setValue(lower_bounds[param_index])
-                param_group['max'].setValue(upper_bounds[param_index])
-                param_index += 1
-
-            if shape == "Pseudo-Voigt":
-                self.eta_spins[peak_index]['init'].setValue(initial_params[param_index])
-                self.eta_spins[peak_index]['min'].setValue(lower_bounds[param_index])
-                self.eta_spins[peak_index]['max'].setValue(upper_bounds[param_index])
-                param_index += 1
-
-        self._update_visualization_combo()
-
-        # Restore the saved visualization key, but treat "R-Squared" as the legacy
-        # default — if it was saved only because it used to be index 0, prefer the
-        # new default "Total_Area" instead.
-        restore_key = saved_visualize_key if saved_visualize_key != "R-Squared" else None
-        if restore_key is not None:
-            selected_index = self.visualization_combo.findData(restore_key)
-            if selected_index >= 0:
-                # Block signals during restore to avoid a double render; emit once after.
-                self.visualization_combo.blockSignals(True)
-                self.visualization_combo.setCurrentIndex(selected_index)
-                self.visualization_combo.blockSignals(False)
-        self._suppress_fitting_config_changed = False
         self.visualization_parameter_changed.emit(self.visualization_combo.currentText())

--- a/map_analysis_2d/ui/main_window.py
+++ b/map_analysis_2d/ui/main_window.py
@@ -882,7 +882,9 @@ class MapAnalysisMainWindow(QMainWindow):
             control_panel.visualization_parameter_changed.connect(self.update_peak_fitting_visualization)
             control_panel.export_batch_requested.connect(self.export_map_peak_fitting_to_batch)
             control_panel.export_results_csv_requested.connect(self.export_map_peak_fitting_results_csv)
-            control_panel.fitting_config_changed.connect(control_panel.results_panel.clear)
+            control_panel.fitting_config_changed.connect(
+                lambda: invalidate_peak_fitting_results(self, control_panel)
+            )
             self.controls_panel.add_section("peak_fitting_controls", control_panel)
 
             restore_config = self.peak_fitting_config or self._saved_peak_fitting_config
@@ -896,6 +898,8 @@ class MapAnalysisMainWindow(QMainWindow):
                 self._pending_peak_fitting_stats = None
 
             if self.peak_fitting_results is not None:
+                if pending is None:
+                    control_panel.results_panel.overall_stats.update_from_fitting_results(self.peak_fitting_results)
                 control_panel.export_batch_btn.setEnabled(True)
                 control_panel.export_results_csv_btn.setEnabled(True)
                 # If config was not set above (no cached config), trigger an initial visualization

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -117,7 +117,7 @@ class OverallStatsWidget(QWidget):
         self.success_rate_label.setToolTip("Percentage of map pixels with complete successful fits.")
         self.failed_fits_label = QLabel("Failed Fits: --")
         self.failed_fits_label.setToolTip(
-            "Pixels where fitting did not succeed. These are counted as not detected / no Si."
+            "Pixels where fitting did not succeed. These are counted as not detected / no signal."
         )
         for label in (self.fitted_pixels_label, self.success_rate_label, self.failed_fits_label):
             self._main_layout.addWidget(label)
@@ -145,7 +145,7 @@ class OverallStatsWidget(QWidget):
         )
         self.no_signal_label = QLabel("Not detected: --")
         self.no_signal_label.setToolTip(
-            "Pixels below the SNR threshold or where fitting failed — treated as no Si detected at this spot."
+            "Pixels below the SNR threshold or where fitting failed — treated as no signal detected at this spot."
         )
         for label in (self.meaningful_pixels_label, self.no_signal_label):
             self._main_layout.addWidget(label)

--- a/map_analysis_2d/ui/overall_stats_widget.py
+++ b/map_analysis_2d/ui/overall_stats_widget.py
@@ -115,7 +115,11 @@ class OverallStatsWidget(QWidget):
         self.fitted_pixels_label.setToolTip("Pixels with all required fitted peak parameters.")
         self.success_rate_label = QLabel("Success Rate: --")
         self.success_rate_label.setToolTip("Percentage of map pixels with complete successful fits.")
-        for label in (self.fitted_pixels_label, self.success_rate_label):
+        self.failed_fits_label = QLabel("Failed Fits: --")
+        self.failed_fits_label.setToolTip(
+            "Pixels where fitting did not succeed. These are counted as not detected / no Si."
+        )
+        for label in (self.fitted_pixels_label, self.success_rate_label, self.failed_fits_label):
             self._main_layout.addWidget(label)
 
         snr_row = QHBoxLayout()
@@ -141,7 +145,7 @@ class OverallStatsWidget(QWidget):
         )
         self.no_signal_label = QLabel("Not detected: --")
         self.no_signal_label.setToolTip(
-            "Pixels below the SNR threshold or that failed to fit — no detectable phase signal at this spot."
+            "Pixels below the SNR threshold or where fitting failed — treated as no Si detected at this spot."
         )
         for label in (self.meaningful_pixels_label, self.no_signal_label):
             self._main_layout.addWidget(label)
@@ -222,6 +226,8 @@ class OverallStatsWidget(QWidget):
         self.fitted_pixels_label.setText("Fitted Pixels: --")
         self.success_rate_label.setText("Success Rate: --")
         self.success_rate_label.setStyleSheet("color: #777;")
+        self.failed_fits_label.setText("Failed Fits: --")
+        self.failed_fits_label.setStyleSheet("color: #777;")
         self.meaningful_pixels_label.setText(f"Detected (SNR ≥ {self.snr_threshold_spin.value():.1f}): --")
         self.meaningful_pixels_label.setStyleSheet("color: #777;")
         self.no_signal_label.setText("Not detected: --")
@@ -266,6 +272,10 @@ class OverallStatsWidget(QWidget):
         self.success_rate_label.setStyleSheet(
             f"color: {self._quality_color(self._stats.success_rate)}; font-weight: bold;"
         )
+        self.failed_fits_label.setText(f"Failed Fits: {self._stats.failed_count:,}")
+        self.failed_fits_label.setStyleSheet(
+            "color: #777;" if self._stats.failed_count == 0 else "color: #c53030; font-weight: bold;"
+        )
 
         threshold = self.snr_threshold_spin.value()
         meaningful = sum(1 for v in self._stats.snr_values if v >= threshold)
@@ -279,9 +289,7 @@ class OverallStatsWidget(QWidget):
         self.meaningful_pixels_label.setStyleSheet(
             f"color: {self._quality_color(meaningful_pct)}; font-weight: bold;"
         )
-        self.no_signal_label.setText(
-            f"Not detected: {no_signal:,} / {total:,}  ({no_signal_pct:.1f}%)"
-        )
+        self.no_signal_label.setText(f"Not detected: {no_signal:,} / {total:,}  ({no_signal_pct:.1f}%)")
 
         self.mean_area_label.setText(
             f"Mean Area: {self._format_number(self._stats.mean_area)} +/- {self._format_number(self._stats.std_area)}"

--- a/map_analysis_2d/ui/test_results_panel_phase5.py
+++ b/map_analysis_2d/ui/test_results_panel_phase5.py
@@ -6,6 +6,8 @@ from PySide6.QtWidgets import QApplication
 
 from map_analysis_2d.ui.pixel_details_widget import PixelDetailsWidget
 from map_analysis_2d.ui.results_panel import ResultsPanel
+from map_analysis_2d.ui.control_panels import MapPeakFittingControlPanel
+from map_analysis_2d.ui.main_window import MapAnalysisMainWindow
 
 
 def _app():
@@ -59,6 +61,84 @@ def test_overall_stats_widget_displays_phase5_metrics_and_histogram():
 
     panel.overall_stats.scientific_toggle.setChecked(True)
     assert "e+" in panel.overall_stats.grand_total_label.text()
+
+
+def test_overall_stats_counts_failed_fits_as_not_detected():
+    _app()
+    panel = ResultsPanel()
+    results = {
+        "peak_shapes": ["Lorentzian"],
+        "map_parameters": {
+            "P1_Amp": {(0, 0): 10.0, (1, 0): 10.0, (2, 0): float("nan")},
+            "P1_Wid": {(0, 0): 3.0, (1, 0): 3.0, (2, 0): float("nan")},
+        },
+        "snr": {(0, 0): 4.0, (1, 0): 1.0},
+        "fit_errors": {(2, 0): "fit failed"},
+    }
+
+    panel.overall_stats.update_from_fitting_results(results)
+
+    assert "Detected" in panel.overall_stats.meaningful_pixels_label.text()
+    assert "1 / 3" in panel.overall_stats.meaningful_pixels_label.text()
+    assert "2 / 3" in panel.overall_stats.no_signal_label.text()
+    assert "Failed Fits: 1" in panel.overall_stats.failed_fits_label.text()
+
+
+def test_peak_fitting_panel_emits_config_changed_for_shape_and_parameter_edits():
+    _app()
+    panel = MapPeakFittingControlPanel()
+    emissions = []
+    panel.fitting_config_changed.connect(lambda: emissions.append(True))
+
+    panel.shape_combos[0].setCurrentText("Gaussian")
+    panel.amp_spins[0]["init"].setValue(panel.amp_spins[0]["init"].value() + 1.0)
+
+    assert len(emissions) >= 2
+
+
+class _DummyControlsPanel:
+    def __init__(self):
+        self.sections = {}
+
+    def clear_dynamic_sections(self):
+        self.sections.clear()
+
+    def add_section(self, name, widget, permanent=False):
+        self.sections[name] = {"widget": widget, "permanent": permanent}
+
+    def add_stretch(self):
+        pass
+
+
+def test_peak_fitting_stats_are_restored_when_recreating_control_panel():
+    _app()
+    window = MapAnalysisMainWindow.__new__(MapAnalysisMainWindow)
+    window.controls_panel = _DummyControlsPanel()
+    window._cache_peak_fitting_config_from_panel = lambda: None
+    window._cache_map_view_settings_from_panel = lambda: None
+    window._get_peak_fitting_tab_index = lambda: 1
+    window._get_map_tab_index = lambda: -1
+    window._get_template_tab_index = lambda: -1
+    window._get_dimensionality_tab_index = lambda: -1
+    window._get_ml_tab_index = lambda: -1
+    window._get_results_tab_index = lambda: -1
+    window._get_microplastic_tab_index = lambda: -1
+    window.peak_fitting_config = None
+    window._saved_peak_fitting_config = None
+    window.map_data = None
+    window.peak_fitting_results = {
+        "peak_shapes": ["Lorentzian"],
+        "map_parameters": {
+            "P1_Amp": {(0, 0): 2.0},
+            "P1_Wid": {(0, 0): 3.0},
+        },
+        "fit_errors": {},
+    }
+
+    window.on_tab_changed(1)
+
+    control_panel = window.controls_panel.sections["peak_fitting_controls"]["widget"]
+    assert "Fitted Pixels: 1 / 1" in control_panel.results_panel.overall_stats.fitted_pixels_label.text()
 
 
 def test_overall_stats_histogram_omits_empty_bins():


### PR DESCRIPTION
## **User description**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale peak-fitting state by fully invalidating previous results when settings change, and improves stats clarity with a visible failed-fits count. Also makes config restore safer to prevent stuck suppression and restores stats on panel reopen.

- **Bug Fixes**
  - Invalidate results on any config change: clear map/spectrum plots, hide the spectrum panel, and disable export until a new run completes.
  - Emit fitting-config changes for shape and parameter edits; suppress extra events during restore and emit once after. Always reset the suppression flag even if restore fails to avoid stuck suppression and stale results.
  - Restore and display overall stats when reopening the panel; tooltips now use generic “no signal” wording.

- **New Features**
  - Add `failed_count` to Overall Stats and show “Failed Fits” (highlighted when > 0).
  - Treat failed fits as “Not detected” in totals and SNR summaries; add tests for plot invalidation, failed-fit counting, config-change emissions, and stats restoration (including control-panel recreation).

<sup>Written for commit 517aa298e9bcc0793eb6da2665f6a665859a8ef4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Clear stale peak-fitting results when settings change and show failed fits in stats**

### What Changed
- Changing peak-fitting settings now clears the old results, removes the displayed plots, hides the spectrum panel, and disables export until a new run finishes.
- Reopening the peak-fitting panel now restores existing results and stats instead of leaving them blank.
- Overall stats now include a visible “Failed Fits” count, and failed fits are treated as not detected in the summary counts.
- Peak-fitting settings changes are now emitted once after edits are restored, avoiding extra refreshes during panel setup.
- Added coverage for plot clearing, failed-fit counting, config-change events, and stats restoration.

### Impact
`✅ Fewer stale peak-fitting results`
`✅ Clearer failed-fit summaries`
`✅ Safer panel restores`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
